### PR TITLE
feat: enforce booking status state machine

### DIFF
--- a/src/features/booking/status-machine.ts
+++ b/src/features/booking/status-machine.ts
@@ -1,0 +1,22 @@
+import { ORPCError } from '@orpc/client';
+
+import type { RequestStatus } from '@/features/booking/schema';
+
+export const VALID_STATUS_TRANSITIONS: Record<RequestStatus, RequestStatus[]> =
+  {
+    REQUESTED: ['ACCEPTED', 'REFUSED', 'CANCELED'],
+    ACCEPTED: ['CANCELED'],
+    REFUSED: [],
+    CANCELED: [],
+  };
+
+export function validateStatusTransition(
+  from: RequestStatus,
+  to: RequestStatus
+): void {
+  if (!VALID_STATUS_TRANSITIONS[from].includes(to)) {
+    throw new ORPCError('BAD_REQUEST', {
+      message: `Cannot transition from ${from} to ${to}`,
+    });
+  }
+}

--- a/src/features/booking/status-machine.unit.test.ts
+++ b/src/features/booking/status-machine.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateStatusTransition } from '@/features/booking/status-machine';
+
+describe('validateStatusTransition', () => {
+  it.each([
+    ['REQUESTED', 'ACCEPTED'],
+    ['REQUESTED', 'REFUSED'],
+    ['REQUESTED', 'CANCELED'],
+    ['ACCEPTED', 'CANCELED'],
+  ] as const)('should allow %s → %s', (from, to) => {
+    expect(() => validateStatusTransition(from, to)).not.toThrow();
+  });
+
+  it.each([
+    ['ACCEPTED', 'ACCEPTED'],
+    ['ACCEPTED', 'REFUSED'],
+    ['REFUSED', 'REQUESTED'],
+    ['REFUSED', 'ACCEPTED'],
+    ['REFUSED', 'CANCELED'],
+    ['CANCELED', 'REQUESTED'],
+    ['CANCELED', 'ACCEPTED'],
+    ['CANCELED', 'REFUSED'],
+  ] as const)('should reject %s → %s', (from, to) => {
+    expect(() => validateStatusTransition(from, to)).toThrow(
+      expect.objectContaining({
+        code: 'BAD_REQUEST',
+        message: `Cannot transition from ${from} to ${to}`,
+      })
+    );
+  });
+});

--- a/src/server/routers/booking.ts
+++ b/src/server/routers/booking.ts
@@ -6,6 +6,7 @@ import {
   zBookingForDriver,
   zBookingRequest,
 } from '@/features/booking/schema';
+import { validateStatusTransition } from '@/features/booking/status-machine';
 import { protectedProcedure } from '@/server/orpc';
 
 const tags = ['bookings'];
@@ -86,6 +87,8 @@ export default {
         throw new ORPCError('FORBIDDEN');
       }
 
+      validateStatusTransition(booking.status, 'ACCEPTED');
+
       await context.db.passengersOnStops.update({
         where: { id: input.id },
         data: { status: 'ACCEPTED' },
@@ -114,6 +117,8 @@ export default {
         throw new ORPCError('FORBIDDEN');
       }
 
+      validateStatusTransition(booking.status, 'REFUSED');
+
       await context.db.passengersOnStops.update({
         where: { id: input.id },
         data: { status: 'REFUSED' },
@@ -140,6 +145,8 @@ export default {
       if (booking.passengerId !== context.user.id) {
         throw new ORPCError('FORBIDDEN');
       }
+
+      validateStatusTransition(booking.status, 'CANCELED');
 
       await context.db.passengersOnStops.update({
         where: { id: input.id },

--- a/src/server/routers/booking.unit.test.ts
+++ b/src/server/routers/booking.unit.test.ts
@@ -163,6 +163,22 @@ describe('booking router', () => {
         code: 'UNAUTHORIZED',
       });
     });
+
+    it.each(['ACCEPTED', 'REFUSED', 'CANCELED'] as const)(
+      'should throw BAD_REQUEST when booking status is %s',
+      async (status) => {
+        mockDb.passengersOnStops.findUnique.mockResolvedValue({
+          ...mockBookingWithStop,
+          status,
+        });
+
+        await expect(
+          call(bookingRouter.accept, acceptInput)
+        ).rejects.toMatchObject({
+          code: 'BAD_REQUEST',
+        });
+      }
+    );
   });
 
   describe('refuse', () => {
@@ -216,6 +232,22 @@ describe('booking router', () => {
         code: 'UNAUTHORIZED',
       });
     });
+
+    it.each(['ACCEPTED', 'REFUSED', 'CANCELED'] as const)(
+      'should throw BAD_REQUEST when booking status is %s',
+      async (status) => {
+        mockDb.passengersOnStops.findUnique.mockResolvedValue({
+          ...mockBookingWithStop,
+          status,
+        });
+
+        await expect(
+          call(bookingRouter.refuse, refuseInput)
+        ).rejects.toMatchObject({
+          code: 'BAD_REQUEST',
+        });
+      }
+    );
   });
 
   describe('cancel', () => {
@@ -258,6 +290,18 @@ describe('booking router', () => {
       });
     });
 
+    it('should succeed when booking status is ACCEPTED', async () => {
+      mockDb.passengersOnStops.findUnique.mockResolvedValue({
+        ...mockBookingFromDb,
+        status: 'ACCEPTED',
+      });
+      mockDb.passengersOnStops.update.mockResolvedValue(undefined);
+
+      await expect(
+        call(bookingRouter.cancel, cancelInput)
+      ).resolves.toBeUndefined();
+    });
+
     it('should throw UNAUTHORIZED when user is not authenticated', async () => {
       mockGetSession.mockResolvedValue(null);
 
@@ -267,6 +311,22 @@ describe('booking router', () => {
         code: 'UNAUTHORIZED',
       });
     });
+
+    it.each(['REFUSED', 'CANCELED'] as const)(
+      'should throw BAD_REQUEST when booking status is %s',
+      async (status) => {
+        mockDb.passengersOnStops.findUnique.mockResolvedValue({
+          ...mockBookingFromDb,
+          status,
+        });
+
+        await expect(
+          call(bookingRouter.cancel, cancelInput)
+        ).rejects.toMatchObject({
+          code: 'BAD_REQUEST',
+        });
+      }
+    );
   });
 
   describe('getRequestsForDriver', () => {


### PR DESCRIPTION
## Summary
- Add a `validateStatusTransition(from, to)` helper in `src/features/booking/status-machine.ts` that throws `BAD_REQUEST` on invalid transitions
- Call it in `accept`, `refuse`, and `cancel` router handlers before updating the DB
- Valid transitions: `REQUESTED→ACCEPTED/REFUSED/CANCELED`, `ACCEPTED→CANCELED`; terminal states (`REFUSED`, `CANCELED`) reject all transitions

- Closes #6
- 
## Test plan
- [x] Unit tests on `validateStatusTransition` cover all 4 valid and 8 invalid transitions
- [x] Router tests verify each handler rejects bookings in invalid starting statuses
- [x] Existing happy-path tests remain green
- [x] `pnpm test:ci` passes (186 tests)