### PR TITLE
feat: auto-accept booking for autoAccept drivers

### DIFF
--- a/src/features/booking/booking-drawer.stories.tsx
+++ b/src/features/booking/booking-drawer.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+
+import { BookingDrawer } from '@/features/booking/booking-drawer';
+
+export default {
+  title: 'Feature/Booking/BookingDrawer',
+} satisfies Meta;
+
+export const Default = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open booking drawer</Button>
+      <BookingDrawer stopId="stop-1" open={open} onOpenChange={setOpen} />
+    </>
+  );
+};

--- a/src/features/booking/booking-drawer.tsx
+++ b/src/features/booking/booking-drawer.tsx
@@ -51,8 +51,14 @@ export const BookingDrawer = (props: {
 
   const bookingRequest = useMutation(
     orpc.booking.request.mutationOptions({
-      onSuccess: async (_data, _variables, _onMutateResult, context) => {
-        toast.success(t('dashboard:booking.successMessage'));
+      onSuccess: async (data, _variables, _onMutateResult, context) => {
+        toast.success(
+          t(
+            data.status === 'ACCEPTED'
+              ? 'dashboard:booking.autoAcceptedMessage'
+              : 'dashboard:booking.successMessage'
+          )
+        );
         await context.client.invalidateQueries({
           queryKey: orpc.commute.getByDate.key(),
           type: 'all',

--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -17,7 +17,7 @@ import { ResponsiveIconButtonLink } from '@/components/ui/responsive-icon-button
 
 import { authClient } from '@/features/auth/client';
 import { CommuteEnriched } from '@/features/commute/schema';
-import { BookingDrawer } from '@/features/dashboard/booking-drawer';
+import { BookingDrawer } from '@/features/booking/booking-drawer';
 import { DashboardCommuteCard } from '@/features/dashboard/dashboard-commute-card';
 import {
   PageLayout,

--- a/src/features/dashboard/dashboard-commute-card.stories.tsx
+++ b/src/features/dashboard/dashboard-commute-card.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta } from '@storybook/react-vite';
+
+import { CommuteEnriched } from '@/features/commute/schema';
+import { DashboardCommuteCard } from '@/features/dashboard/dashboard-commute-card';
+
+export default {
+  title: 'Feature/Dashboard/DashboardCommuteCard',
+} satisfies Meta;
+
+const now = new Date();
+
+const mockStop = (
+  id: string,
+  order: number,
+  passengers: CommuteEnriched['stops'][number]['passengers'] = []
+): CommuteEnriched['stops'][number] => ({
+  id,
+  order,
+  outwardTime: '08:00',
+  inwardTime: '18:00',
+  locationId: `loc-${id}`,
+  commuteId: 'commute-1',
+  createdAt: now,
+  updatedAt: now,
+  location: { id: `loc-${id}`, name: `Stop ${order + 1}` },
+  passengers,
+});
+
+const baseCommute: CommuteEnriched = {
+  id: 'commute-1',
+  date: now,
+  seats: 4,
+  type: 'ROUND',
+  status: 'UNKNOWN',
+  delay: null,
+  comment: null,
+  driverId: 'driver-1',
+  createdAt: now,
+  updatedAt: now,
+  driver: { id: 'driver-1', name: 'Alice Martin', image: null },
+  stops: [mockStop('stop-1', 0), mockStop('stop-2', 1)],
+};
+
+const noop = () => Promise.resolve();
+const noopMutation = { mutateAsync: noop } as ExplicitAny;
+
+export const Default = () => {
+  return (
+    <DashboardCommuteCard
+      commute={baseCommute}
+      currentUserId="passenger-1"
+      commuteCancel={noopMutation}
+      bookingCancel={noopMutation}
+      onBookStop={noop}
+    />
+  );
+};
+
+export const WithPendingBooking = () => {
+  const commute: CommuteEnriched = {
+    ...baseCommute,
+    stops: [
+      mockStop('stop-1', 0, [
+        {
+          id: 'booking-1',
+          status: 'REQUESTED',
+          tripType: 'ROUND',
+          comment: null,
+          passenger: { id: 'passenger-1', name: 'Bob Dupont', image: null },
+        },
+      ]),
+      mockStop('stop-2', 1),
+    ],
+  };
+
+  return (
+    <DashboardCommuteCard
+      commute={commute}
+      currentUserId="passenger-1"
+      commuteCancel={noopMutation}
+      bookingCancel={noopMutation}
+      onBookStop={noop}
+    />
+  );
+};
+
+export const WithAcceptedBooking = () => {
+  const commute: CommuteEnriched = {
+    ...baseCommute,
+    stops: [
+      mockStop('stop-1', 0, [
+        {
+          id: 'booking-1',
+          status: 'ACCEPTED',
+          tripType: 'ROUND',
+          comment: null,
+          passenger: { id: 'passenger-1', name: 'Bob Dupont', image: null },
+        },
+      ]),
+      mockStop('stop-2', 1),
+    ],
+  };
+
+  return (
+    <DashboardCommuteCard
+      commute={commute}
+      currentUserId="passenger-1"
+      commuteCancel={noopMutation}
+      bookingCancel={noopMutation}
+      onBookStop={noop}
+    />
+  );
+};
+
+export const AsDriver = () => {
+  return (
+    <DashboardCommuteCard
+      commute={baseCommute}
+      currentUserId="driver-1"
+      commuteCancel={noopMutation}
+      bookingCancel={noopMutation}
+      onBookStop={noop}
+    />
+  );
+};
+
+export const FullSeats = () => {
+  const passengers = [
+    {
+      id: 'b-1',
+      status: 'ACCEPTED' as const,
+      tripType: 'ROUND' as const,
+      comment: null,
+      passenger: { id: 'p-1', name: 'Bob Dupont', image: null },
+    },
+    {
+      id: 'b-2',
+      status: 'ACCEPTED' as const,
+      tripType: 'ONEWAY' as const,
+      comment: null,
+      passenger: { id: 'p-2', name: 'Charlie Durand', image: null },
+    },
+    {
+      id: 'b-3',
+      status: 'ACCEPTED' as const,
+      tripType: 'ROUND' as const,
+      comment: null,
+      passenger: { id: 'p-3', name: 'Diana Moreau', image: null },
+    },
+    {
+      id: 'b-4',
+      status: 'ACCEPTED' as const,
+      tripType: 'RETURN' as const,
+      comment: null,
+      passenger: { id: 'p-4', name: 'Émile Petit', image: null },
+    },
+  ];
+
+  const commute: CommuteEnriched = {
+    ...baseCommute,
+    stops: [
+      mockStop('stop-1', 0, passengers.slice(0, 2)),
+      mockStop('stop-2', 1, passengers.slice(2)),
+    ],
+  };
+
+  return (
+    <DashboardCommuteCard
+      commute={commute}
+      currentUserId="other-user"
+      commuteCancel={noopMutation}
+      bookingCancel={noopMutation}
+      onBookStop={noop}
+    />
+  );
+};

--- a/src/features/dashboard/dashboard-commute-card.tsx
+++ b/src/features/dashboard/dashboard-commute-card.tsx
@@ -2,6 +2,7 @@ import { UseMutationResult } from '@tanstack/react-query';
 import { Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   CardCommute,
@@ -114,20 +115,34 @@ export const DashboardCommuteCard = ({
               );
               if (userBooking) {
                 return (
-                  <ConfirmResponsiveDrawer
-                    description={t(
-                      'dashboard:cancelBooking.confirmDescription'
-                    )}
-                    confirmText={t('common:actions.delete')}
-                    confirmVariant="destructive"
-                    onConfirm={() =>
-                      bookingCancel.mutateAsync({ id: userBooking.id })
-                    }
-                  >
-                    <Button size="xs" variant="destructive">
-                      {t('common:actions.cancel')}
-                    </Button>
-                  </ConfirmResponsiveDrawer>
+                  <div className="flex items-center gap-1.5">
+                    <Badge
+                      size="xs"
+                      variant={
+                        userBooking.status === 'ACCEPTED'
+                          ? 'positive'
+                          : 'warning'
+                      }
+                    >
+                      {t(
+                        `dashboard:booking.status.${userBooking.status as 'REQUESTED' | 'ACCEPTED'}`
+                      )}
+                    </Badge>
+                    <ConfirmResponsiveDrawer
+                      description={t(
+                        'dashboard:cancelBooking.confirmDescription'
+                      )}
+                      confirmText={t('common:actions.delete')}
+                      confirmVariant="destructive"
+                      onConfirm={() =>
+                        bookingCancel.mutateAsync({ id: userBooking.id })
+                      }
+                    >
+                      <Button size="xs" variant="destructive">
+                        {t('common:actions.cancel')}
+                      </Button>
+                    </ConfirmResponsiveDrawer>
+                  </div>
                 );
               }
               if (hasBookingOnCommute) return null;

--- a/src/locales/en/dashboard.json
+++ b/src/locales/en/dashboard.json
@@ -17,7 +17,12 @@
     "commentPlaceholder": "Optional comment...",
     "submitButton": "Book",
     "successMessage": "Booking request sent",
-    "errorMessage": "Failed to send booking request. Please try again."
+    "autoAcceptedMessage": "Booking confirmed",
+    "errorMessage": "Failed to send booking request. Please try again.",
+    "status": {
+      "REQUESTED": "Pending",
+      "ACCEPTED": "Confirmed"
+    }
   },
   "cancelBooking": {
     "confirmDescription": "You are about to cancel your booking.",

--- a/src/locales/fr/dashboard.json
+++ b/src/locales/fr/dashboard.json
@@ -17,7 +17,12 @@
     "commentPlaceholder": "Commentaire optionnel...",
     "submitButton": "Réserver",
     "successMessage": "Demande de réservation envoyée",
-    "errorMessage": "Échec de l'envoi de la demande de réservation. Veuillez réessayer."
+    "autoAcceptedMessage": "Réservation confirmée",
+    "errorMessage": "Échec de l'envoi de la demande de réservation. Veuillez réessayer.",
+    "status": {
+      "REQUESTED": "En attente",
+      "ACCEPTED": "Confirmée"
+    }
   },
   "cancelBooking": {
     "confirmDescription": "Vous êtes sur le point d'annuler votre réservation.",

--- a/src/server/routers/booking.ts
+++ b/src/server/routers/booking.ts
@@ -20,10 +20,13 @@ export default {
     .input(zBookingRequest())
     .output(zBooking())
     .handler(async ({ context, input }) => {
-      // Find the commute this stop belongs to
+      // Find the commute this stop belongs to, including driver's autoAccept setting
       const stop = await context.db.stop.findUnique({
         where: { id: input.stopId },
-        select: { commuteId: true },
+        select: {
+          commuteId: true,
+          commute: { select: { driver: { select: { autoAccept: true } } } },
+        },
       });
 
       if (!stop) {
@@ -45,6 +48,8 @@ export default {
         });
       }
 
+      const status = stop.commute.driver.autoAccept ? 'ACCEPTED' : 'REQUESTED';
+
       return await context.db.passengersOnStops.upsert({
         where: {
           passengerId_stopId: {
@@ -53,12 +58,13 @@ export default {
           },
         },
         update: {
-          status: 'REQUESTED',
+          status,
           tripType: input.tripType,
           comment: input.comment,
         },
         create: {
           ...input,
+          status,
           passengerId: context.user.id,
         },
       });

--- a/src/server/routers/booking.unit.test.ts
+++ b/src/server/routers/booking.unit.test.ts
@@ -53,8 +53,11 @@ describe('booking router', () => {
       comment: 'Pick me up please',
     };
 
-    it('should succeed for an authenticated user', async () => {
-      mockDb.stop.findUnique.mockResolvedValue({ commuteId: 'commute-1' });
+    it('should create a REQUESTED booking when driver has autoAccept disabled', async () => {
+      mockDb.stop.findUnique.mockResolvedValue({
+        commuteId: 'commute-1',
+        commute: { driver: { autoAccept: false } },
+      });
       mockDb.passengersOnStops.findFirst.mockResolvedValue(null);
       mockDb.passengersOnStops.upsert.mockResolvedValue(mockBookingFromDb);
 
@@ -75,6 +78,42 @@ describe('booking router', () => {
         },
         create: {
           ...requestInput,
+          status: 'REQUESTED',
+          passengerId: mockUser.id,
+        },
+      });
+    });
+
+    it('should auto-accept booking when driver has autoAccept enabled', async () => {
+      const autoAcceptedBooking = {
+        ...mockBookingFromDb,
+        status: 'ACCEPTED' as const,
+      };
+      mockDb.stop.findUnique.mockResolvedValue({
+        commuteId: 'commute-1',
+        commute: { driver: { autoAccept: true } },
+      });
+      mockDb.passengersOnStops.findFirst.mockResolvedValue(null);
+      mockDb.passengersOnStops.upsert.mockResolvedValue(autoAcceptedBooking);
+
+      const result = await call(bookingRouter.request, requestInput);
+
+      expect(result).toEqual(autoAcceptedBooking);
+      expect(mockDb.passengersOnStops.upsert).toHaveBeenCalledWith({
+        where: {
+          passengerId_stopId: {
+            passengerId: mockUser.id,
+            stopId: requestInput.stopId,
+          },
+        },
+        update: {
+          status: 'ACCEPTED',
+          tripType: requestInput.tripType,
+          comment: requestInput.comment,
+        },
+        create: {
+          ...requestInput,
+          status: 'ACCEPTED',
           passengerId: mockUser.id,
         },
       });


### PR DESCRIPTION
## Summary
- When a driver has `autoAccept: true`, booking requests are created with status `ACCEPTED` directly instead of `REQUESTED`
- The dashboard commute card now shows a status badge next to the cancel button: **Pending** (orange) for `REQUESTED`, **Confirmed** (green) for `ACCEPTED`
- The booking toast message adapts: "Booking confirmed" for auto-accepted, "Booking request sent" otherwise
- Moved `BookingDrawer` from `features/dashboard` to `features/booking`
- Added Storybook stories for `DashboardCommuteCard` and `BookingDrawer`

Closes #7

## Test plan
- [x] Unit tests cover both `autoAccept: true` (status = ACCEPTED) and `autoAccept: false` (status = REQUESTED) flows
- [x] Verify status badge renders correctly in Storybook (`WithPendingBooking` / `WithAcceptedBooking` stories)
- [x] Manually test booking flow with a driver that has autoAccept enabled/disabled