### PR TITLE
feat: template picker in commute creation flow

### DIFF
--- a/src/features/commute-template/card-commute-template-header.tsx
+++ b/src/features/commute-template/card-commute-template-header.tsx
@@ -1,6 +1,6 @@
-import { useTranslation } from 'react-i18next';
-
 import { CardAction, CardDescription, CardTitle } from '@/components/ui/card';
+
+import { CommuteTemplateSummary } from '@/features/commute-template/commute-template-summary';
 
 type CardCommuteTemplateHeaderProps = {
   name: React.ReactNode;
@@ -17,19 +17,17 @@ export const CardCommuteTemplateHeader = ({
   seats,
   actions,
 }: CardCommuteTemplateHeaderProps) => {
-  const { t } = useTranslation(['commuteTemplate']);
-
   return (
     <>
       <div className="flex items-center gap-2">
         <CardTitle>{name}</CardTitle>
       </div>
       <CardDescription>
-        {type}
-        {' · '}
-        {t('commuteTemplate:list.stops', { count: stopsCount })}
-        {' · '}
-        {t('commuteTemplate:list.seats', { count: seats })}
+        <CommuteTemplateSummary
+          type={type}
+          stopsCount={stopsCount}
+          seats={seats}
+        />
       </CardDescription>
       {actions && <CardAction>{actions}</CardAction>}
     </>

--- a/src/features/commute-template/commute-template-summary.tsx
+++ b/src/features/commute-template/commute-template-summary.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next';
+
+export const CommuteTemplateSummary = ({
+  type,
+  stopsCount,
+  seats,
+}: {
+  type: 'ROUND' | 'ONEWAY';
+  stopsCount: number;
+  seats: number;
+}) => {
+  const { t } = useTranslation(['commute', 'commuteTemplate']);
+
+  return (
+    <>
+      {t(`commute:list.type.${type}`)} &middot;{' '}
+      {t('commuteTemplate:list.stops', { count: stopsCount })} &middot;{' '}
+      {t('commute:list.seats', { count: seats })}
+    </>
+  );
+};

--- a/src/features/commute/app/page-commute-new.tsx
+++ b/src/features/commute/app/page-commute-new.tsx
@@ -1,6 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
 import { useCanGoBack, useRouter } from '@tanstack/react-router';
+import { PenLineIcon } from 'lucide-react';
+import { useState } from 'react';
 import { FormStateSubscribe, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -13,6 +15,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
 import { FormCommute } from '@/features/commute/app/form-commute';
+import { TemplatePicker } from '@/features/commute/app/template-picker';
 import {
   FormFieldsCommute,
   zFormFieldsCommute,
@@ -24,18 +27,22 @@ import {
   PageLayoutTopBarTitle,
 } from '@/layout/app/page-layout';
 
+const DEFAULT_VALUES: Omit<FormFieldsCommute, 'date'> = {
+  seats: 1,
+  type: 'ROUND',
+  comment: null,
+  stops: [{ locationId: '', outwardTime: '', inwardTime: null }],
+};
+
 export const PageCommuteNew = () => {
   const { t } = useTranslation(['commute']);
   const router = useRouter();
   const canGoBack = useCanGoBack();
+  const [showForm, setShowForm] = useState(false);
+
   const form = useForm<FormFieldsCommute>({
     resolver: zodResolver(zFormFieldsCommute()),
-    defaultValues: {
-      seats: 1,
-      type: 'ROUND',
-      comment: null,
-      stops: [{ locationId: '', outwardTime: '', inwardTime: null }],
-    },
+    defaultValues: DEFAULT_VALUES,
   });
 
   const commuteCreate = useMutation(
@@ -58,6 +65,34 @@ export const PageCommuteNew = () => {
       },
     })
   );
+
+  if (!showForm) {
+    return (
+      <PageLayout>
+        <PageLayoutTopBar startActions={<BackButton />}>
+          <PageLayoutTopBarTitle>
+            {t('commute:new.title')}
+          </PageLayoutTopBarTitle>
+        </PageLayoutTopBar>
+        <PageLayoutContent containerClassName="gap-4">
+          <Button
+            variant="secondary"
+            className="w-full"
+            onClick={() => setShowForm(true)}
+          >
+            <PenLineIcon />
+            {t('commute:templatePicker.fromScratch')}
+          </Button>
+          <TemplatePicker
+            onSelect={(data) => {
+              form.reset({ ...DEFAULT_VALUES, ...data });
+              setShowForm(true);
+            }}
+          />
+        </PageLayoutContent>
+      </PageLayout>
+    );
+  }
 
   return (
     <>

--- a/src/features/commute/app/template-picker.tsx
+++ b/src/features/commute/app/template-picker.tsx
@@ -1,0 +1,120 @@
+import { getUiState } from '@bearstudio/ui-state';
+import { useQuery } from '@tanstack/react-query';
+import { PlusIcon, RepeatIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { orpc } from '@/lib/orpc/client';
+
+import { ButtonLink } from '@/components/ui/button-link';
+import {
+  Empty,
+  EmptyContent,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import type { FormFieldsCommute } from '@/features/commute/schema';
+import { CommuteTemplateSummary } from '@/features/commute-template/commute-template-summary';
+
+type TemplateData = Pick<
+  FormFieldsCommute,
+  'seats' | 'type' | 'comment' | 'stops'
+>;
+
+export const TemplatePicker = ({
+  onSelect,
+}: {
+  onSelect: (data: TemplateData) => void;
+}) => {
+  const { t } = useTranslation(['commute', 'commuteTemplate']);
+
+  const templatesQuery = useQuery(
+    orpc.commuteTemplate.getAll.queryOptions({
+      input: { limit: 100 },
+    })
+  );
+
+  const handleSelect = (
+    item: NonNullable<typeof templatesQuery.data>['items'][number]
+  ) => {
+    onSelect({
+      seats: item.seats,
+      type: item.type,
+      comment: item.comment ?? null,
+      stops: item.stops.map((stop) => ({
+        locationId: stop.locationId,
+        outwardTime: stop.outwardTime,
+        inwardTime: stop.inwardTime ?? null,
+      })),
+    });
+  };
+
+  const ui = getUiState((set) => {
+    if (templatesQuery.status === 'pending') return set('pending');
+    if (templatesQuery.status === 'error') return set('error');
+    const items = templatesQuery.data?.items ?? [];
+    if (!items.length) return set('empty');
+    return set('default', { items });
+  });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-sm font-medium">
+        {t('commute:templatePicker.title')}
+      </h3>
+      {ui
+        .match('pending', () => (
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {[1, 0.75, 0.5].map((opacity) => (
+              <Skeleton key={opacity} className="h-20" style={{ opacity }} />
+            ))}
+          </div>
+        ))
+        .match('error', () => null)
+        .match('empty', () => (
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <RepeatIcon />
+              </EmptyMedia>
+              <EmptyTitle>{t('commute:templatePicker.emptyState')}</EmptyTitle>
+            </EmptyHeader>
+            <EmptyContent>
+              <ButtonLink
+                to="/app/account/commute-templates/new"
+                variant="secondary"
+                size="sm"
+              >
+                <PlusIcon />
+                {t('commuteTemplate:list.newAction')}
+              </ButtonLink>
+            </EmptyContent>
+          </Empty>
+        ))
+        .match('default', ({ items }) => (
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {items.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => handleSelect(item)}
+                className="flex cursor-pointer flex-col items-start gap-1 rounded-lg border p-3 text-left text-sm transition-colors hover:bg-muted/50"
+              >
+                <span className="font-medium">{item.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  <CommuteTemplateSummary
+                    type={item.type}
+                    stopsCount={item.stops.length}
+                    seats={item.seats}
+                  />
+                </span>
+              </button>
+            ))}
+          </div>
+        ))
+        .exhaustive()}
+    </div>
+  );
+};

--- a/src/locales/en/commute.json
+++ b/src/locales/en/commute.json
@@ -22,6 +22,11 @@
     "title": "New Commute",
     "submitButton": "Create"
   },
+  "templatePicker": {
+    "title": "My templates",
+    "emptyState": "Save time: create a template",
+    "fromScratch": "Create from scratch"
+  },
   "form": {
     "date": "Date",
     "seats": "Seats",

--- a/src/locales/fr/commute.json
+++ b/src/locales/fr/commute.json
@@ -22,6 +22,11 @@
     "title": "Nouveau trajet",
     "submitButton": "Créer"
   },
+  "templatePicker": {
+    "title": "Mes modèles",
+    "emptyState": "Gagnez du temps : créez un modèle",
+    "fromScratch": "Créer de zéro"
+  },
   "form": {
     "date": "Date",
     "seats": "Places",


### PR DESCRIPTION
## Summary
- Adds a template selection screen before the commute creation form
- Users can pick a template to pre-fill the form (seats, type, comment, stops) or "Create from scratch"
- Once a choice is made, the form view is identical to the original create commute page
- Includes i18n translations (en/fr)

## Test plan
- [x] Navigate to `/app/commutes/new` — verify the picker screen shows templates and a "Create from scratch" button
- [x] Click a template card — verify form opens pre-filled with template data
- [x] Click "Create from scratch" — verify form opens with default values
- [x] On mobile, verify cards and button take full width
- [x] Verify empty state links to template creation page