### PR TITLE
feat: commute date validation and future-only filtering

### DIFF
--- a/src/components/form/form-field-error.tsx
+++ b/src/components/form/form-field-error.tsx
@@ -89,7 +89,7 @@ export const FormFieldError = <
       )}
       {...rest}
     >
-      <AlertCircleIcon size="1em" className="my-0.5 flex-none" />
+      <AlertCircleIcon size="1em" className="my-0.75 flex-none" />
       {errorMessage}
     </div>
   );

--- a/src/features/commute/app/form-commute.tsx
+++ b/src/features/commute/app/form-commute.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
-import { useFormContext } from 'react-hook-form';
+import { AlertTriangleIcon } from 'lucide-react';
+import { Control, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -10,6 +11,25 @@ import {
 
 import { FormCommuteSharedFields } from '@/features/commute/form-commute-shared-fields';
 import type { FormFieldsCommute } from '@/features/commute/schema';
+
+const TodayWarning = ({ control }: { control: Control<FormFieldsCommute> }) => {
+  const { t } = useTranslation(['commute']);
+  const selectedDate = useWatch({ control, name: 'date' });
+  const isToday = selectedDate && dayjs(selectedDate).isToday();
+
+  if (!isToday) return null;
+
+  return (
+    <p
+      className="dark:text-warnoing-400 flex animate-in gap-1 text-sm text-warning-600 slide-in-from-top-1"
+      role="status"
+      aria-live="polite"
+    >
+      <AlertTriangleIcon size="1em" className="my-0.75 flex-none" />
+      {t('commute:form.todayWarning')}
+    </p>
+  );
+};
 
 export const FormCommute = () => {
   const { t } = useTranslation(['commute']);
@@ -30,6 +50,7 @@ export const FormCommute = () => {
             startMonth: today,
           }}
         />
+        <TodayWarning control={form.control} />
       </FormField>
 
       <FormCommuteSharedFields

--- a/src/features/commute/form-commute-rules.ts
+++ b/src/features/commute/form-commute-rules.ts
@@ -1,0 +1,13 @@
+import dayjs from 'dayjs';
+
+export const isTimeInFuture = (date: Date, time: string) => {
+  const [hours = 0, minutes = 0] = time.split(':').map(Number);
+  return dayjs(date).hour(hours).minute(minutes).isAfter(dayjs());
+};
+
+export const isInwardAfterOutward = (
+  outwardTime: string,
+  inwardTime: string
+) => {
+  return inwardTime > outwardTime;
+};

--- a/src/features/commute/schema.ts
+++ b/src/features/commute/schema.ts
@@ -1,8 +1,13 @@
+import dayjs from 'dayjs';
 import { t } from 'i18next';
 import { z } from 'zod';
 
 import { zu } from '@/lib/zod/zod-utils';
 
+import {
+  isInwardAfterOutward,
+  isTimeInFuture,
+} from '@/features/commute/form-commute-rules';
 import { zLocation } from '@/features/location/schema';
 import { zUser } from '@/features/user/schema';
 
@@ -61,18 +66,62 @@ export const zFormFieldsStopInput = () =>
 
 export type FormFieldsCommute = z.infer<ReturnType<typeof zFormFieldsCommute>>;
 export const zFormFieldsCommute = () =>
-  z.object({
-    date: z.date({ error: t('common:errors.required') }),
-    seats: z
-      .number({ error: t('common:errors.required') })
-      .int()
-      .min(1, t('commute:form.errors.seatsMin')),
-    type: zCommuteType(),
-    comment: zu.fieldText.nullish(),
-    stops: z
-      .array(zFormFieldsStopInput())
-      .min(1, t('commute:form.errors.stopsMin')),
-  });
+  z
+    .object({
+      date: z.date({ error: t('common:errors.required') }),
+      seats: z
+        .number({ error: t('common:errors.required') })
+        .int()
+        .min(1, t('commute:form.errors.seatsMin')),
+      type: zCommuteType(),
+      comment: zu.fieldText.nullish(),
+      stops: z
+        .array(zFormFieldsStopInput())
+        .min(1, t('commute:form.errors.stopsMin')),
+    })
+    .superRefine((data, ctx) => {
+      const isToday = dayjs(data.date).isToday();
+
+      data.stops.forEach((stop, index) => {
+        if (
+          isToday &&
+          stop.outwardTime &&
+          !isTimeInFuture(data.date, stop.outwardTime)
+        ) {
+          ctx.addIssue({
+            code: 'custom',
+            message: t('commute:form.errors.outwardInPast'),
+            path: ['stops', index, 'outwardTime'],
+          });
+        }
+
+        if (
+          data.type === 'ROUND' &&
+          stop.inwardTime &&
+          stop.outwardTime &&
+          !isInwardAfterOutward(stop.outwardTime, stop.inwardTime)
+        ) {
+          ctx.addIssue({
+            code: 'custom',
+            message: t('commute:form.errors.inwardBeforeOutward'),
+            path: ['stops', index, 'inwardTime'],
+          });
+        }
+
+        if (
+          isToday &&
+          data.type === 'ROUND' &&
+          stop.inwardTime &&
+          !isTimeInFuture(data.date, stop.inwardTime)
+        ) {
+          ctx.addIssue({
+            code: 'custom',
+            message: t('commute:form.errors.inwardInPast'),
+            path: ['stops', index, 'inwardTime'],
+          });
+        }
+      });
+    });
 
 export type UserSummary = z.infer<ReturnType<typeof zUserSummary>>;
 export const zUserSummary = () =>

--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -38,14 +38,14 @@ export const PageDashboard = () => {
   const currentUserId = session.data?.user.id ?? '';
   const [bookingStopId, setBookingStopId] = useState<string | null>(null);
 
-  const weekStart = dayjs().startOf('isoWeek');
-  const weekEnd = weekStart.add(7, 'day');
+  const today = dayjs().startOf('day');
+  const rangeEnd = today.add(7, 'day');
 
   const commutesQuery = useQuery(
     orpc.commute.getByDate.queryOptions({
       input: {
-        from: weekStart.toDate(),
-        to: weekEnd.toDate(),
+        from: today.toDate(),
+        to: rangeEnd.toDate(),
       },
     })
   );
@@ -85,9 +85,8 @@ export const PageDashboard = () => {
     commutesByDay.set(key, existing);
   }
 
-  // Generate all 7 days (Mon-Sun)
-  const days = Array.from({ length: 7 }, (_, i) => weekStart.add(i, 'day'));
-  const today = dayjs().format('YYYY-MM-DD');
+  // Generate 7 days starting from today
+  const days = Array.from({ length: 7 }, (_, i) => today.add(i, 'day'));
 
   const ui = getUiState((set) => {
     if (commutesQuery.status === 'pending') return set('pending');
@@ -121,7 +120,7 @@ export const PageDashboard = () => {
             <div className="flex flex-col gap-6">
               {days.map((day) => {
                 const key = day.format('YYYY-MM-DD');
-                const isToday = key === today;
+                const isToday = day.isToday();
                 const dayCommutes = commutesByDay.get(key) ?? [];
 
                 return (

--- a/src/lib/dayjs/config.ts
+++ b/src/lib/dayjs/config.ts
@@ -1,8 +1,10 @@
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import isoWeek from 'dayjs/plugin/isoWeek';
+import isToday from 'dayjs/plugin/isToday';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 dayjs.extend(relativeTime);
 dayjs.extend(customParseFormat);
 dayjs.extend(isoWeek);
+dayjs.extend(isToday);

--- a/src/locales/en/commute.json
+++ b/src/locales/en/commute.json
@@ -45,9 +45,13 @@
     "roundTrip": "Round trip",
     "outwardTime": "Outward time",
     "inwardTime": "Inward time",
+    "todayWarning": "You are creating a commute for today. Make sure the times are still valid.",
     "errors": {
       "seatsMin": "At least 1 seat required",
-      "stopsMin": "At least 1 stop required"
+      "stopsMin": "At least 1 stop required",
+      "inwardBeforeOutward": "Inward time must be after outward time",
+      "inwardInPast": "Inward time must be in the future",
+      "outwardInPast": "Outward time must be in the future"
     }
   }
 }

--- a/src/locales/fr/commute.json
+++ b/src/locales/fr/commute.json
@@ -45,9 +45,13 @@
     "roundTrip": "Aller-retour",
     "outwardTime": "Heure aller",
     "inwardTime": "Heure retour",
+    "todayWarning": "Vous créez un trajet pour aujourd'hui. Vérifiez que les horaires sont encore valides.",
     "errors": {
       "seatsMin": "Au moins 1 place requise",
-      "stopsMin": "Au moins 1 arrêt requis"
+      "stopsMin": "Au moins 1 arrêt requis",
+      "inwardBeforeOutward": "L'heure retour doit être après l'heure aller",
+      "inwardInPast": "L'heure retour doit être dans le futur",
+      "outwardInPast": "L'heure aller doit être dans le futur"
     }
   }
 }

--- a/src/server/routers/commute.ts
+++ b/src/server/routers/commute.ts
@@ -142,7 +142,11 @@ export default {
       })
     )
     .handler(async ({ context, input }) => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
       const where = {
+        date: { gte: today },
         OR: [
           { driverId: context.user.id },
           {
@@ -179,7 +183,7 @@ export default {
         context.db.commute.findMany({
           take: input.limit + 1,
           cursor: input.cursor ? { id: input.cursor } : undefined,
-          orderBy: { createdAt: 'desc' },
+          orderBy: { date: 'asc' },
           where,
           include,
         }),

--- a/src/server/routers/commute.unit.spec.ts
+++ b/src/server/routers/commute.unit.spec.ts
@@ -224,6 +224,7 @@ describe('commute router', () => {
       expect(mockDb.commute.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
+            date: { gte: expect.any(Date) },
             OR: [
               { driverId: mockUser.id },
               {


### PR DESCRIPTION
## Summary
- Add a warning in the commute creation form when the selected date is today
- Validate that outward and inward times are in the future when creating a commute for today
- Validate that inward time is after outward time for round trips
- Dashboard now shows 7 days starting from today (instead of current ISO week)
- My commutes page only shows future commutes, ordered by date ascending
- Register dayjs `isToday` plugin for cleaner date checks
- Fix form error icon alignment with first line of multi-line messages

## Test plan
- [x] Create a commute for today with a past outward time — should show validation error
- [x] Create a round-trip commute with inward time before outward time — should show validation error
- [x] Create a round-trip commute for today with a past inward time — should show validation error
- [x] Select today's date in the form — should show orange warning message
- [x] Verify dashboard shows 7 days starting from today
- [x] Verify my commutes page only lists future commutes