### PR TITLE
feat: add Prisma satisfies annotations to router variables

### DIFF
--- a/src/server/routers/booking.ts
+++ b/src/server/routers/booking.ts
@@ -7,6 +7,7 @@ import {
   zBookingRequest,
 } from '@/features/booking/schema';
 import { validateStatusTransition } from '@/features/booking/status-machine';
+import { Prisma } from '@/server/db/generated/client';
 import { protectedProcedure } from '@/server/orpc';
 
 const tags = ['bookings'];
@@ -314,7 +315,7 @@ export default {
             driverId: context.user.id,
           },
         },
-      };
+      } satisfies Prisma.PassengersOnStopsWhereInput;
 
       const include = {
         passenger: { select: { id: true, name: true, image: true } },
@@ -333,7 +334,7 @@ export default {
             },
           },
         },
-      };
+      } satisfies Prisma.PassengersOnStopsInclude;
 
       const [total, items] = await Promise.all([
         context.db.passengersOnStops.count({ where }),

--- a/src/server/routers/commute-template.ts
+++ b/src/server/routers/commute-template.ts
@@ -8,6 +8,7 @@ import {
   zTemplateStop,
   zTemplateStopWithLocation,
 } from '@/features/commute-template/schema';
+import { Prisma } from '@/server/db/generated/client';
 import { protectedProcedure } from '@/server/orpc';
 
 const tags = ['commute-templates'];
@@ -61,7 +62,9 @@ export default {
       })
     )
     .handler(async ({ context, input }) => {
-      const where = { driverId: context.user.id };
+      const where = {
+        driverId: context.user.id,
+      } satisfies Prisma.CommuteTemplateWhereInput;
 
       const [total, items] = await Promise.all([
         context.db.commuteTemplate.count({ where }),

--- a/src/server/routers/commute.ts
+++ b/src/server/routers/commute.ts
@@ -172,7 +172,7 @@ export default {
             },
           },
         },
-      };
+      } satisfies Prisma.CommuteInclude;
 
       const [total, items] = await Promise.all([
         context.db.commute.count({ where }),

--- a/src/server/routers/location.ts
+++ b/src/server/routers/location.ts
@@ -2,6 +2,7 @@ import { ORPCError } from '@orpc/client';
 import { z } from 'zod';
 
 import { zFormFieldsLocation, zLocation } from '@/features/location/schema';
+import { Prisma } from '@/server/db/generated/client';
 import { protectedProcedure } from '@/server/orpc';
 
 const tags = ['locations'];
@@ -50,7 +51,9 @@ export default {
       })
     )
     .handler(async ({ context, input }) => {
-      const where = { userId: context.user.id };
+      const where = {
+        userId: context.user.id,
+      } satisfies Prisma.LocationWhereInput;
 
       const [total, items] = await Promise.all([
         context.db.location.count({ where }),


### PR DESCRIPTION
## Summary
- Adds `satisfies Prisma.<Type>` annotations to extracted `where` and `include` variables in `booking.ts`, `commute-template.ts`, `commute.ts`, and `location.ts` routers
- Restores compile-time type checking on variables that lose Prisma type context when separated from the query call
- Adds `Prisma` import to the three files that didn't have it yet

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] All 146 router unit tests pass
- [x] Pre-commit and pre-push hooks pass (lint + typecheck)