### PR TITLE
feat: separate user and org scoped settings on account pages

### DIFF
--- a/src/features/account/app/page-account.tsx
+++ b/src/features/account/app/page-account.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 
 import { DisplayPreferences } from '@/features/account/display-preferences';
+import { MemberPreferences } from '@/features/account/member-preferences';
 import { NotificationPreferences } from '@/features/account/notification-preferences';
 import { UserCard } from '@/features/account/user-card';
 import { authClient } from '@/features/auth/client';
@@ -53,39 +54,55 @@ export const PageAccount = () => {
         </h1>
       </PageLayoutTopBar>
       <PageLayoutContent>
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-6">
           <div className="md:hidden">
             <OrgSwitcher />
           </div>
-          <UserCard />
-          {showManagerLink && (
+
+          <section className="flex flex-col gap-4">
+            <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              {t('account:sections.personal')}
+            </h2>
+            <UserCard />
+            <DisplayPreferences />
+          </section>
+
+          <section className="flex flex-col gap-4">
+            <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              {t('account:sections.organization')}
+            </h2>
+            <MemberPreferences />
+            <NotificationPreferences />
+            {showManagerLink && (
+              <OrgLink
+                to="/manager"
+                className="flex items-center gap-3 rounded-lg border bg-card p-4 text-sm font-medium transition-colors hover:bg-accent"
+              >
+                <SettingsIcon className="size-5 text-muted-foreground" />
+                <span className="flex-1">{t('account:managerLink')}</span>
+                <ChevronRightIcon className="size-4 text-muted-foreground" />
+              </OrgLink>
+            )}
             <OrgLink
-              to="/manager"
+              to="/app/$orgSlug/account/locations"
               className="flex items-center gap-3 rounded-lg border bg-card p-4 text-sm font-medium transition-colors hover:bg-accent"
             >
-              <SettingsIcon className="size-5 text-muted-foreground" />
-              <span className="flex-1">{t('account:managerLink')}</span>
+              <MapPinIcon className="size-5 text-muted-foreground" />
+              <span className="flex-1">{t('account:locationsLink')}</span>
               <ChevronRightIcon className="size-4 text-muted-foreground" />
             </OrgLink>
-          )}
-          <OrgLink
-            to="/app/$orgSlug/account/locations"
-            className="flex items-center gap-3 rounded-lg border bg-card p-4 text-sm font-medium transition-colors hover:bg-accent"
-          >
-            <MapPinIcon className="size-5 text-muted-foreground" />
-            <span className="flex-1">{t('account:locationsLink')}</span>
-            <ChevronRightIcon className="size-4 text-muted-foreground" />
-          </OrgLink>
-          <OrgLink
-            to="/app/$orgSlug/account/commute-templates"
-            className="flex items-center gap-3 rounded-lg border bg-card p-4 text-sm font-medium transition-colors hover:bg-accent"
-          >
-            <RepeatIcon className="size-5 text-muted-foreground" />
-            <span className="flex-1">{t('account:commuteTemplatesLink')}</span>
-            <ChevronRightIcon className="size-4 text-muted-foreground" />
-          </OrgLink>
-          <NotificationPreferences />
-          <DisplayPreferences />
+            <OrgLink
+              to="/app/$orgSlug/account/commute-templates"
+              className="flex items-center gap-3 rounded-lg border bg-card p-4 text-sm font-medium transition-colors hover:bg-accent"
+            >
+              <RepeatIcon className="size-5 text-muted-foreground" />
+              <span className="flex-1">
+                {t('account:commuteTemplatesLink')}
+              </span>
+              <ChevronRightIcon className="size-4 text-muted-foreground" />
+            </OrgLink>
+          </section>
+
           <BuildInfoDrawer>
             <Button variant="ghost" size="xs" className="opacity-60">
               <BuildInfoVersion />

--- a/src/features/account/manager/page-account.tsx
+++ b/src/features/account/manager/page-account.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 
 import { DisplayPreferences } from '@/features/account/display-preferences';
+import { MemberPreferences } from '@/features/account/member-preferences';
 import { UserCard } from '@/features/account/user-card';
 import { BuildInfoDrawer } from '@/features/build-info/build-info-drawer';
 import { BuildInfoVersion } from '@/features/build-info/build-info-version';
@@ -21,9 +22,22 @@ export const PageAccount = () => {
         <PageLayoutTopBarTitle>{t('account:title')}</PageLayoutTopBarTitle>
       </PageLayoutTopBar>
       <PageLayoutContent>
-        <div className="flex flex-col gap-4">
-          <UserCard />
-          <DisplayPreferences />
+        <div className="flex flex-col gap-6">
+          <section className="flex flex-col gap-4">
+            <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              {t('account:sections.personal')}
+            </h2>
+            <UserCard />
+            <DisplayPreferences />
+          </section>
+
+          <section className="flex flex-col gap-4">
+            <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              {t('account:sections.organization')}
+            </h2>
+            <MemberPreferences />
+          </section>
+
           <BuildInfoDrawer>
             <Button variant="ghost" size="xs" className="opacity-60">
               <BuildInfoVersion />

--- a/src/features/account/member-preferences.tsx
+++ b/src/features/account/member-preferences.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from 'react-i18next';
+
+import { Card, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { AccountCardRow } from '@/features/account/account-card-row';
+import { AutoAcceptToggle } from '@/features/account/auto-accept-toggle';
+
+export const MemberPreferences = () => {
+  const { t } = useTranslation(['account']);
+  return (
+    <Card className="gap-0 p-0">
+      <CardHeader className="gap-y-0 py-4">
+        <CardTitle>{t('account:memberPreferences.title')}</CardTitle>
+      </CardHeader>
+      <AccountCardRow
+        label={t('account:userCard.autoAccept.label')}
+        className="sm:items-center"
+      >
+        <AutoAcceptToggle />
+      </AccountCardRow>
+    </Card>
+  );
+};

--- a/src/features/account/user-card.tsx
+++ b/src/features/account/user-card.tsx
@@ -7,7 +7,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardAction, CardHeader, CardTitle } from '@/components/ui/card';
 
 import { AccountCardRow } from '@/features/account/account-card-row';
-import { AutoAcceptToggle } from '@/features/account/auto-accept-toggle';
 import { EditNameDrawer } from '@/features/account/edit-name-drawer';
 import { EditPhoneDrawer } from '@/features/account/edit-phone-drawer';
 import { authClient } from '@/features/auth/client';
@@ -90,12 +89,6 @@ export const UserCard = () => {
             </span>
           </Button>
         </EditPhoneDrawer>
-      </AccountCardRow>
-      <AccountCardRow
-        label={t('account:userCard.autoAccept.label')}
-        className="sm:items-center"
-      >
-        <AutoAcceptToggle />
       </AccountCardRow>
     </Card>
   );

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -1,7 +1,14 @@
 {
   "title": "Account",
+  "sections": {
+    "personal": "Personal",
+    "organization": "Organization"
+  },
   "displayPreferences": {
     "title": "Display Preferences"
+  },
+  "memberPreferences": {
+    "title": "Preferences"
   },
   "userCard": {
     "name": {

--- a/src/locales/fr/account.json
+++ b/src/locales/fr/account.json
@@ -1,7 +1,14 @@
 {
   "title": "Compte",
+  "sections": {
+    "personal": "Personnel",
+    "organization": "Organisation"
+  },
   "displayPreferences": {
     "title": "Préférences d'affichage"
+  },
+  "memberPreferences": {
+    "title": "Préférences"
   },
   "userCard": {
     "name": {


### PR DESCRIPTION
## Summary
- Add "Personal" and "Organization" section headers to account pages (app + manager)
- Extract auto-accept toggle from `UserCard` into a new `MemberPreferences` card under the Organization section
- Group user-scoped settings (profile info, display preferences) under Personal, and org-scoped settings (auto-accept, notifications, org links) under Organization

## Test plan
- [x] Check `/app/{orgSlug}/account` — verify Personal and Organization sections appear with correct grouping
- [x] Check `/manager/{orgSlug}/account` — same verification
- [x] Toggle locale to French and verify section headers translate correctly
- [x] Verify mobile responsive layout still works