### PR TITLE
feat: active commute state and phone validation

### DIFF
--- a/src/devtools/actions/force-active-commute-action.tsx
+++ b/src/devtools/actions/force-active-commute-action.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+import { DEVTOOLS_FORCE_ACTIVE_COMMUTE_KEY } from '@/features/commute/commute-active';
+
+export function ForceActiveCommuteAction() {
+  const [enabled, setEnabled] = useState(
+    () => localStorage.getItem(DEVTOOLS_FORCE_ACTIVE_COMMUTE_KEY) === 'true'
+  );
+
+  const toggle = () => {
+    const next = !enabled;
+    if (next) {
+      localStorage.setItem(DEVTOOLS_FORCE_ACTIVE_COMMUTE_KEY, 'true');
+    } else {
+      localStorage.removeItem(DEVTOOLS_FORCE_ACTIVE_COMMUTE_KEY);
+    }
+    setEnabled(next);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Force Active Commute</CardTitle>
+        <CardDescription>
+          Make all commute cards appear as active
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          variant={enabled ? 'destructive' : 'secondary'}
+          size="sm"
+          onClick={toggle}
+        >
+          {enabled ? 'Disable' : 'Enable'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/devtools/actions/index.tsx
+++ b/src/devtools/actions/index.tsx
@@ -1,5 +1,6 @@
 import { ClearDbAction } from './clear-db-action';
 import { DbSeedAction } from './db-actions';
+import { ForceActiveCommuteAction } from './force-active-commute-action';
 import { SwitchUserAction } from './switch-user-action';
 
 export function ActionsDevtoolPanel() {
@@ -9,6 +10,7 @@ export function ActionsDevtoolPanel() {
         <DbSeedAction />
         <ClearDbAction />
         <SwitchUserAction />
+        <ForceActiveCommuteAction />
       </div>
     </div>
   );

--- a/src/features/account/schema.ts
+++ b/src/features/account/schema.ts
@@ -1,3 +1,4 @@
+import { t } from 'i18next';
 import { z } from 'zod';
 
 import { zu } from '@/lib/zod/zod-utils';
@@ -15,5 +16,7 @@ export type FormFieldsAccountUpdatePhone = z.infer<
 >;
 export const zFormFieldsAccountUpdatePhone = () =>
   z.object({
-    phone: zu.fieldText.nullish(),
+    phone: zu.fieldText
+      .nullish()
+      .pipe(zu.phone({ invalid: t('auth:common.phone.invalid') })),
   });

--- a/src/features/auth/schema.ts
+++ b/src/features/auth/schema.ts
@@ -38,5 +38,7 @@ export type FormFieldsOnboarding = z.infer<
 export const zFormFieldsOnboarding = () =>
   z.object({
     name: zu.fieldText.required(),
-    phone: zu.fieldText.nullish(),
+    phone: zu.fieldText
+      .nullish()
+      .pipe(zu.phone({ invalid: t('auth:common.phone.invalid') })),
   });

--- a/src/features/commute/app/page-active-commute.tsx
+++ b/src/features/commute/app/page-active-commute.tsx
@@ -1,0 +1,84 @@
+import { getUiState } from '@bearstudio/ui-state';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { orpc } from '@/lib/orpc/client';
+
+import { BackButton } from '@/components/back-button';
+import {
+  DataListErrorState,
+  DataListLoadingState,
+} from '@/components/ui/datalist';
+
+import { authClient } from '@/features/auth/client';
+import {
+  PageLayout,
+  PageLayoutContent,
+  PageLayoutTopBar,
+  PageLayoutTopBarTitle,
+} from '@/layout/app/page-layout';
+
+export const PageActiveCommute = ({
+  params,
+}: {
+  params: { commuteId: string; orgSlug: string };
+}) => {
+  const { commuteId } = params;
+  const { t } = useTranslation(['commute']);
+  const session = authClient.useSession();
+  const currentUserId = session.data?.user.id ?? '';
+
+  const commuteQuery = useQuery(
+    orpc.commute.getById.queryOptions({
+      input: { id: commuteId },
+    })
+  );
+
+  const ui = getUiState((set) => {
+    if (commuteQuery.status === 'pending') return set('pending');
+    if (commuteQuery.status === 'error') return set('error');
+    return set('default', { commute: commuteQuery.data! });
+  });
+
+  return (
+    <PageLayout>
+      <PageLayoutTopBar startActions={<BackButton />}>
+        <PageLayoutTopBarTitle>
+          {t('commute:active.title')}
+        </PageLayoutTopBarTitle>
+      </PageLayoutTopBar>
+      <PageLayoutContent>
+        {ui
+          .match('pending', () => <DataListLoadingState />)
+          .match('error', () => (
+            <DataListErrorState retry={() => commuteQuery.refetch()} />
+          ))
+          .match('default', ({ commute }) => {
+            const isDriver = currentUserId === commute.driver.id;
+            return isDriver ? (
+              <ActiveCommuteDriverView />
+            ) : (
+              <ActiveCommutePassengerView />
+            );
+          })
+          .exhaustive()}
+      </PageLayoutContent>
+    </PageLayout>
+  );
+};
+
+function ActiveCommuteDriverView() {
+  return (
+    <div className="flex items-center justify-center p-12 text-muted-foreground">
+      Driver view — coming soon
+    </div>
+  );
+}
+
+function ActiveCommutePassengerView() {
+  return (
+    <div className="flex items-center justify-center p-12 text-muted-foreground">
+      Passenger view — coming soon
+    </div>
+  );
+}

--- a/src/features/commute/app/page-commutes.tsx
+++ b/src/features/commute/app/page-commutes.tsx
@@ -6,7 +6,9 @@ import { toast } from 'sonner';
 
 import { orpc } from '@/lib/orpc/client';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardHeader } from '@/components/ui/card';
 import {
   CardCommute,
   CardCommuteContent,
@@ -29,7 +31,9 @@ import { ResponsiveIconButton } from '@/components/ui/responsive-icon-button';
 import { authClient } from '@/features/auth/client';
 import { CardCommutePassengersList } from '@/features/commute/card-commute-passengers-list';
 import { CardCommuteStopsList } from '@/features/commute/card-commute-stops-list';
+import { isCommuteActive } from '@/features/commute/commute-active';
 import { OrgResponsiveIconButtonLink } from '@/features/organization/org-button-link';
+import { OrgLink } from '@/features/organization/org-link';
 import {
   PageLayout,
   PageLayoutContent,
@@ -123,6 +127,36 @@ export const PageCommutes = () => {
                 }
                 const available = item.seats - acceptedPassengers.size;
                 const isDriver = session.data?.user.id === item.driver.id;
+                const isActive = isCommuteActive(item);
+
+                if (isActive) {
+                  return (
+                    <OrgLink
+                      key={item.id}
+                      to="/app/$orgSlug/commutes/$commuteId"
+                      params={{ commuteId: item.id }}
+                      className="block no-underline"
+                    >
+                      <Card className="cursor-pointer transition-colors hover:bg-accent/50">
+                        <CardHeader>
+                          <CardCommuteHeader
+                            driver={item.driver}
+                            date={item.date}
+                            status={item.status}
+                            type={item.type}
+                            availableSeats={available}
+                            totalSeats={item.seats}
+                            actions={
+                              <Badge variant="warning" size="sm">
+                                {t('commute:active.badge')}
+                              </Badge>
+                            }
+                          />
+                        </CardHeader>
+                      </Card>
+                    </OrgLink>
+                  );
+                }
 
                 return (
                   <CardCommute key={item.id}>

--- a/src/features/commute/commute-active.ts
+++ b/src/features/commute/commute-active.ts
@@ -1,0 +1,33 @@
+import dayjs from 'dayjs';
+
+import { CommuteEnriched } from '@/features/commute/schema';
+
+const ACTIVE_THRESHOLD_HOURS = 3;
+export const DEVTOOLS_FORCE_ACTIVE_COMMUTE_KEY =
+  'devtools:force-active-commute';
+
+export function isCommuteActive(commute: CommuteEnriched): boolean {
+  if (typeof window !== 'undefined') {
+    try {
+      if (localStorage.getItem(DEVTOOLS_FORCE_ACTIVE_COMMUTE_KEY) === 'true') {
+        return true;
+      }
+    } catch {
+      // localStorage unavailable
+    }
+  }
+
+  const earliestTime = commute.stops.map((s) => s.outwardTime).sort()[0];
+
+  if (!earliestTime) return false;
+
+  const [hours = 0, minutes = 0] = earliestTime.split(':').map(Number);
+  const departureAt = dayjs(commute.date).hour(hours).minute(minutes);
+  const now = dayjs();
+  const endOfCommuteDay = dayjs(commute.date).endOf('day');
+
+  return (
+    now.isBefore(endOfCommuteDay) &&
+    departureAt.diff(now, 'hour', true) <= ACTIVE_THRESHOLD_HOURS
+  );
+}

--- a/src/features/dashboard/dashboard-commute-card.tsx
+++ b/src/features/dashboard/dashboard-commute-card.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardHeader } from '@/components/ui/card';
 import {
   CardCommute,
   CardCommuteContent,
@@ -15,7 +16,9 @@ import { ResponsiveIconButton } from '@/components/ui/responsive-icon-button';
 
 import { CardCommutePassengersList } from '@/features/commute/card-commute-passengers-list';
 import { CardCommuteStopsList } from '@/features/commute/card-commute-stops-list';
+import { isCommuteActive } from '@/features/commute/commute-active';
 import { CommuteEnriched, StopEnriched } from '@/features/commute/schema';
+import { OrgLink } from '@/features/organization/org-link';
 
 type DashboardCommuteCardProps = {
   commute: CommuteEnriched;
@@ -59,6 +62,36 @@ export const DashboardCommuteCard = ({
         (p.status === 'REQUESTED' || p.status === 'ACCEPTED')
     )
   );
+
+  const isActive = isCommuteActive(commute);
+
+  if (isActive) {
+    return (
+      <OrgLink
+        to="/app/$orgSlug/commutes/$commuteId"
+        params={{ commuteId: commute.id }}
+        className="block no-underline"
+      >
+        <Card className="cursor-pointer transition-colors hover:bg-accent/50">
+          <CardHeader>
+            <CardCommuteHeader
+              driver={commute.driver}
+              date={commute.date}
+              status={commute.status}
+              type={commute.type}
+              availableSeats={available}
+              totalSeats={commute.seats}
+              actions={
+                <Badge variant="warning" size="sm">
+                  {t('commute:active.badge')}
+                </Badge>
+              }
+            />
+          </CardHeader>
+        </Card>
+      </OrgLink>
+    );
+  }
 
   return (
     <CardCommute>

--- a/src/lib/zod/zod-utils.ts
+++ b/src/lib/zod/zod-utils.ts
@@ -10,6 +10,11 @@ const emptyStringAsUndefined = (input: string) =>
   input.trim() === '' ? (undefined as unknown as string) : input.trim();
 
 export const zu = {
+  phone: (params: { invalid: string }) =>
+    z
+      .string()
+      .regex(/^[\d\s+\-().]+$/, params.invalid)
+      .nullish(),
   fieldText: {
     required: (
       params: Parameters<typeof z.string>[0] = t('common:errors.required')

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -76,7 +76,8 @@
     },
     "phone": {
       "onboardingLabel": "What is your phone number?",
-      "label": "Phone"
+      "label": "Phone",
+      "invalid": "Invalid phone number"
     }
   },
   "errorCode": {

--- a/src/locales/en/commute.json
+++ b/src/locales/en/commute.json
@@ -27,6 +27,10 @@
     "emptyState": "Save time: create a template",
     "fromScratch": "Create from scratch"
   },
+  "active": {
+    "title": "Commute Details",
+    "badge": "Active"
+  },
   "form": {
     "date": "Date",
     "seats": "Seats",

--- a/src/locales/fr/auth.json
+++ b/src/locales/fr/auth.json
@@ -45,7 +45,8 @@
     },
     "phone": {
       "onboardingLabel": "Quel est votre numéro de téléphone?",
-      "label": "Téléphone"
+      "label": "Téléphone",
+      "invalid": "Numéro de téléphone invalide"
     }
   },
   "errorCode": {

--- a/src/locales/fr/commute.json
+++ b/src/locales/fr/commute.json
@@ -27,6 +27,10 @@
     "emptyState": "Gagnez du temps : créez un modèle",
     "fromScratch": "Créer de zéro"
   },
+  "active": {
+    "title": "Détails du trajet",
+    "badge": "Actif"
+  },
   "form": {
     "date": "Date",
     "seats": "Places",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -51,6 +51,7 @@ import { Route as ManagerOrgSlugUsersNewIndexRouteImport } from './routes/manage
 import { Route as ManagerOrgSlugUsersIdIndexRouteImport } from './routes/manager/$orgSlug/users/$id.index'
 import { Route as ManagerOrgSlugOrganizationsIdIndexRouteImport } from './routes/manager/$orgSlug/organizations/$id.index'
 import { Route as AppOrgSlugCommutesNewIndexRouteImport } from './routes/app/$orgSlug/commutes/new.index'
+import { Route as AppOrgSlugCommutesCommuteIdIndexRouteImport } from './routes/app/$orgSlug/commutes/$commuteId.index'
 import { Route as AppOrgSlugAccountLocationsIndexRouteImport } from './routes/app/$orgSlug/account/locations/index'
 import { Route as AppOrgSlugAccountCommuteTemplatesIndexRouteImport } from './routes/app/$orgSlug/account/commute-templates/index'
 import { Route as ManagerOrgSlugUsersIdUpdateIndexRouteImport } from './routes/manager/$orgSlug/users/$id.update.index'
@@ -280,6 +281,12 @@ const AppOrgSlugCommutesNewIndexRoute =
     path: '/commutes/new/',
     getParentRoute: () => AppOrgSlugRouteRoute,
   } as any)
+const AppOrgSlugCommutesCommuteIdIndexRoute =
+  AppOrgSlugCommutesCommuteIdIndexRouteImport.update({
+    id: '/commutes/$commuteId/',
+    path: '/commutes/$commuteId/',
+    getParentRoute: () => AppOrgSlugRouteRoute,
+  } as any)
 const AppOrgSlugAccountLocationsIndexRoute =
   AppOrgSlugAccountLocationsIndexRouteImport.update({
     id: '/account/locations/',
@@ -363,6 +370,7 @@ export interface FileRoutesByFullPath {
   '/manager/users/new/': typeof ManagerUsersNewIndexRoute
   '/app/$orgSlug/account/commute-templates/': typeof AppOrgSlugAccountCommuteTemplatesIndexRoute
   '/app/$orgSlug/account/locations/': typeof AppOrgSlugAccountLocationsIndexRoute
+  '/app/$orgSlug/commutes/$commuteId/': typeof AppOrgSlugCommutesCommuteIdIndexRoute
   '/app/$orgSlug/commutes/new/': typeof AppOrgSlugCommutesNewIndexRoute
   '/manager/$orgSlug/organizations/$id/': typeof ManagerOrgSlugOrganizationsIdIndexRoute
   '/manager/$orgSlug/users/$id/': typeof ManagerOrgSlugUsersIdIndexRoute
@@ -407,6 +415,7 @@ export interface FileRoutesByTo {
   '/manager/users/new': typeof ManagerUsersNewIndexRoute
   '/app/$orgSlug/account/commute-templates': typeof AppOrgSlugAccountCommuteTemplatesIndexRoute
   '/app/$orgSlug/account/locations': typeof AppOrgSlugAccountLocationsIndexRoute
+  '/app/$orgSlug/commutes/$commuteId': typeof AppOrgSlugCommutesCommuteIdIndexRoute
   '/app/$orgSlug/commutes/new': typeof AppOrgSlugCommutesNewIndexRoute
   '/manager/$orgSlug/organizations/$id': typeof ManagerOrgSlugOrganizationsIdIndexRoute
   '/manager/$orgSlug/users/$id': typeof ManagerOrgSlugUsersIdIndexRoute
@@ -459,6 +468,7 @@ export interface FileRoutesById {
   '/manager/users/new/': typeof ManagerUsersNewIndexRoute
   '/app/$orgSlug/account/commute-templates/': typeof AppOrgSlugAccountCommuteTemplatesIndexRoute
   '/app/$orgSlug/account/locations/': typeof AppOrgSlugAccountLocationsIndexRoute
+  '/app/$orgSlug/commutes/$commuteId/': typeof AppOrgSlugCommutesCommuteIdIndexRoute
   '/app/$orgSlug/commutes/new/': typeof AppOrgSlugCommutesNewIndexRoute
   '/manager/$orgSlug/organizations/$id/': typeof ManagerOrgSlugOrganizationsIdIndexRoute
   '/manager/$orgSlug/users/$id/': typeof ManagerOrgSlugUsersIdIndexRoute
@@ -512,6 +522,7 @@ export interface FileRouteTypes {
     | '/manager/users/new/'
     | '/app/$orgSlug/account/commute-templates/'
     | '/app/$orgSlug/account/locations/'
+    | '/app/$orgSlug/commutes/$commuteId/'
     | '/app/$orgSlug/commutes/new/'
     | '/manager/$orgSlug/organizations/$id/'
     | '/manager/$orgSlug/users/$id/'
@@ -556,6 +567,7 @@ export interface FileRouteTypes {
     | '/manager/users/new'
     | '/app/$orgSlug/account/commute-templates'
     | '/app/$orgSlug/account/locations'
+    | '/app/$orgSlug/commutes/$commuteId'
     | '/app/$orgSlug/commutes/new'
     | '/manager/$orgSlug/organizations/$id'
     | '/manager/$orgSlug/users/$id'
@@ -607,6 +619,7 @@ export interface FileRouteTypes {
     | '/manager/users/new/'
     | '/app/$orgSlug/account/commute-templates/'
     | '/app/$orgSlug/account/locations/'
+    | '/app/$orgSlug/commutes/$commuteId/'
     | '/app/$orgSlug/commutes/new/'
     | '/manager/$orgSlug/organizations/$id/'
     | '/manager/$orgSlug/users/$id/'
@@ -931,6 +944,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppOrgSlugCommutesNewIndexRouteImport
       parentRoute: typeof AppOrgSlugRouteRoute
     }
+    '/app/$orgSlug/commutes/$commuteId/': {
+      id: '/app/$orgSlug/commutes/$commuteId/'
+      path: '/commutes/$commuteId'
+      fullPath: '/app/$orgSlug/commutes/$commuteId/'
+      preLoaderRoute: typeof AppOrgSlugCommutesCommuteIdIndexRouteImport
+      parentRoute: typeof AppOrgSlugRouteRoute
+    }
     '/app/$orgSlug/account/locations/': {
       id: '/app/$orgSlug/account/locations/'
       path: '/account/locations'
@@ -990,6 +1010,7 @@ interface AppOrgSlugRouteRouteChildren {
   AppOrgSlugRequestsIndexRoute: typeof AppOrgSlugRequestsIndexRoute
   AppOrgSlugAccountCommuteTemplatesIndexRoute: typeof AppOrgSlugAccountCommuteTemplatesIndexRoute
   AppOrgSlugAccountLocationsIndexRoute: typeof AppOrgSlugAccountLocationsIndexRoute
+  AppOrgSlugCommutesCommuteIdIndexRoute: typeof AppOrgSlugCommutesCommuteIdIndexRoute
   AppOrgSlugCommutesNewIndexRoute: typeof AppOrgSlugCommutesNewIndexRoute
   AppOrgSlugAccountCommuteTemplatesNewIndexRoute: typeof AppOrgSlugAccountCommuteTemplatesNewIndexRoute
   AppOrgSlugAccountLocationsNewIndexRoute: typeof AppOrgSlugAccountLocationsNewIndexRoute
@@ -1005,6 +1026,7 @@ const AppOrgSlugRouteRouteChildren: AppOrgSlugRouteRouteChildren = {
   AppOrgSlugAccountCommuteTemplatesIndexRoute:
     AppOrgSlugAccountCommuteTemplatesIndexRoute,
   AppOrgSlugAccountLocationsIndexRoute: AppOrgSlugAccountLocationsIndexRoute,
+  AppOrgSlugCommutesCommuteIdIndexRoute: AppOrgSlugCommutesCommuteIdIndexRoute,
   AppOrgSlugCommutesNewIndexRoute: AppOrgSlugCommutesNewIndexRoute,
   AppOrgSlugAccountCommuteTemplatesNewIndexRoute:
     AppOrgSlugAccountCommuteTemplatesNewIndexRoute,

--- a/src/routes/app/$orgSlug/commutes/$commuteId.index.tsx
+++ b/src/routes/app/$orgSlug/commutes/$commuteId.index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { PageActiveCommute } from '@/features/commute/app/page-active-commute';
+
+export const Route = createFileRoute('/app/$orgSlug/commutes/$commuteId/')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <PageActiveCommute params={Route.useParams()} />;
+}

--- a/src/server/routers/commute.ts
+++ b/src/server/routers/commute.ts
@@ -71,21 +71,52 @@ export default {
       tags,
     })
     .input(z.object({ id: z.string() }))
-    .output(zCommute().extend({ stops: z.array(zStop()) }))
+    .output(zCommuteEnriched())
     .handler(async ({ context, input }) => {
       const commute = await context.db.commute.findFirst({
         where: {
           id: input.id,
           driver: { organizationId: context.organizationId },
         },
-        include: { stops: true },
+        include: {
+          driver: {
+            include: {
+              user: { select: { id: true, name: true, image: true } },
+            },
+          },
+          stops: {
+            orderBy: { order: 'asc' },
+            include: {
+              location: { select: { id: true, name: true } },
+              passengers: {
+                include: {
+                  passenger: {
+                    include: {
+                      user: { select: { id: true, name: true, image: true } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       });
 
       if (!commute) {
         throw new ORPCError('NOT_FOUND');
       }
 
-      return commute;
+      return {
+        ...commute,
+        driver: commute.driver.user,
+        stops: commute.stops.map((s) => ({
+          ...s,
+          passengers: s.passengers.map((p) => ({
+            ...p,
+            passenger: p.passenger.user,
+          })),
+        })),
+      };
     }),
 
   getByDate: organizationProcedure({

--- a/src/server/routers/commute.unit.spec.ts
+++ b/src/server/routers/commute.unit.spec.ts
@@ -130,15 +130,15 @@ describe('commute router', () => {
 
   describe('getById', () => {
     it('should return a commute with stops when found', async () => {
-      mockDb.commute.findFirst.mockResolvedValue(mockCommuteFromDb);
+      mockDb.commute.findFirst.mockResolvedValue(mockCommuteEnrichedRawFromDb);
 
       const result = await call(commuteRouter.getById, { id: 'commute-1' });
 
-      expect(result).toEqual(mockCommuteFromDb);
+      expect(result).toEqual(mockCommuteEnriched);
     });
 
     it('should scope query by organizationId via driver relation', async () => {
-      mockDb.commute.findFirst.mockResolvedValue(mockCommuteFromDb);
+      mockDb.commute.findFirst.mockResolvedValue(mockCommuteEnrichedRawFromDb);
 
       await call(commuteRouter.getById, { id: 'commute-1' });
 


### PR DESCRIPTION
## Summary
- When a commute is within 3 hours of departure (or the devtools toggle is on), commute cards on the dashboard and "my commutes" pages become clickable with an "Active" badge, navigating to a new detail page at `/app/$orgSlug/commutes/$commuteId`
- The detail page determines driver vs passenger and renders placeholder views (content to be implemented later)
- Enriches the `getById` backend procedure to return full `CommuteEnriched` data
- Extracts phone regex validation into a shared `zu.phone()` zod utility used by both `auth/schema.ts` and `account/schema.ts`
- Adds a devtools toggle ("Force Active Commute") to simulate the active state during development

## Test plan
- [ ] Enable "Force Active Commute" in devtools → all commute cards show "Active" badge and become clickable
- [ ] Click an active card → navigates to `/app/{orgSlug}/commutes/{commuteId}` showing driver or passenger placeholder
- [ ] Disable the toggle → cards revert to normal collapsible behavior
- [ ] Verify phone validation shows error on invalid input in onboarding and account update forms
- [ ] `pnpm tsc --noEmit` passes