### PR TITLE
feat: surface Locations & Templates from My Commutes

### DIFF
--- a/src/features/commute/app/page-commutes.tsx
+++ b/src/features/commute/app/page-commutes.tsx
@@ -1,6 +1,12 @@
 import { getUiState } from '@bearstudio/ui-state';
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
-import { CarIcon, PlusIcon, Trash2 } from 'lucide-react';
+import {
+  CarIcon,
+  MapPinIcon,
+  PlusIcon,
+  RepeatIcon,
+  Trash2,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
@@ -38,7 +44,12 @@ import {
 } from '@/layout/app/page-layout';
 
 export const PageCommutes = () => {
-  const { t } = useTranslation(['commute', 'common']);
+  const { t } = useTranslation([
+    'commute',
+    'common',
+    'location',
+    'commuteTemplate',
+  ]);
   const session = authClient.useSession();
 
   const commutesQuery = useInfiniteQuery(
@@ -76,14 +87,32 @@ export const PageCommutes = () => {
     <PageLayout>
       <PageLayoutTopBar
         endActions={
-          <OrgResponsiveIconButtonLink
-            label={t('commute:list.newAction')}
-            variant="secondary"
-            size="sm"
-            to="/app/$orgSlug/commutes/new"
-          >
-            <PlusIcon />
-          </OrgResponsiveIconButtonLink>
+          <>
+            <OrgResponsiveIconButtonLink
+              label={t('location:list.title')}
+              variant="ghost"
+              size="sm"
+              to="/app/$orgSlug/account/locations"
+            >
+              <MapPinIcon />
+            </OrgResponsiveIconButtonLink>
+            <OrgResponsiveIconButtonLink
+              label={t('commuteTemplate:list.title')}
+              variant="ghost"
+              size="sm"
+              to="/app/$orgSlug/account/commute-templates"
+            >
+              <RepeatIcon />
+            </OrgResponsiveIconButtonLink>
+            <OrgResponsiveIconButtonLink
+              label={t('commute:list.newAction')}
+              variant="secondary"
+              size="sm"
+              to="/app/$orgSlug/commutes/new"
+            >
+              <PlusIcon />
+            </OrgResponsiveIconButtonLink>
+          </>
         }
       >
         <PageLayoutTopBarTitle>{t('commute:list.title')}</PageLayoutTopBarTitle>


### PR DESCRIPTION
## Summary
- Adds Locations (MapPin icon) and Commute Templates (Repeat icon) navigation links to the My Commutes page top bar
- Uses `ghost` variant to visually differentiate them from the primary `secondary` "New Commute" action
- On mobile: icon-only; on desktop: icon + label
- Existing Account page links remain as a secondary discovery path

## Why
Locations and Commute Templates were only accessible from the Account page, buried under the "Organization" section. Users don't naturally look there for commute-related setup. Surfacing them from "My Commutes" puts them where users naturally look.

## Test plan
- [x] Navigate to "My Commutes" — 3 buttons visible in top bar (Locations, Templates, + New Commute)
- [x] Click Locations icon → navigates to Locations page
- [x] Click Templates icon → navigates to Commute Templates page
- [x] Click "+ New Commute" → still works as before
- [x] Resize to mobile width → all 3 buttons show as icon-only
- [x] Account page → Locations and Commute Templates links still work