### PR TITLE
feat: centralize date formats with typed feature-scoped keys

### DIFF
--- a/src/components/ui/calendar.stories.tsx
+++ b/src/components/ui/calendar.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta } from '@storybook/react-vite';
 import dayjs from 'dayjs';
 import { useState } from 'react';
 
+import { formatDate } from '@/lib/dayjs/formats';
+
 import { Calendar } from '@/components/ui/calendar';
 
 export default {
@@ -35,7 +37,7 @@ export const Controlled = () => {
       footer={
         <div className="mt-4 text-sm">
           {selected
-            ? `Selected: ${dayjs(selected).format('DD/MM/YYYY')}`
+            ? `Selected: ${formatDate(selected, 'common:short')}`
             : 'Pick a day'}
         </div>
       }

--- a/src/components/ui/date-input.tsx
+++ b/src/components/ui/date-input.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react';
 
+import { getDateFormat } from '@/lib/dayjs/formats';
 import { parseStringToDate } from '@/lib/dayjs/parse-string-to-date';
 import { toNoonUTC } from '@/lib/dayjs/to-noon-utc';
 
@@ -69,7 +70,7 @@ export const useDatePickerInputManagement = (
 
     const isNewValue = !date.isSame(dateValue, 'date');
     if (!isNewValue) {
-      setInputValue(date.format('DD/MM/YYYY'));
+      setInputValue(date.format(dateFormat));
       // To avoid the issue of non-selection when:
       // * The input is focused with an already selected value
       // * A new date is clicked directly
@@ -88,7 +89,7 @@ export const DateInput = ({
   onBlur,
   onKeyDown,
   value,
-  format = 'DD/MM/YYYY',
+  format = getDateFormat('common:short'),
   ...props
 }: Omit<ComponentProps<typeof Input>, 'onChange' | 'value'> & {
   onChange?: (date: Date | null) => void;

--- a/src/components/ui/date-picker-button.stories.tsx
+++ b/src/components/ui/date-picker-button.stories.tsx
@@ -4,6 +4,8 @@ import { DateRange } from 'react-day-picker';
 import { useDisclosure } from 'react-use-disclosure';
 import { isNullish } from 'remeda';
 
+import { formatDate } from '@/lib/dayjs/formats';
+
 import { Calendar } from '@/components/ui/calendar';
 import { DatePickerButton } from '@/components/ui/date-picker-button';
 import {
@@ -35,7 +37,9 @@ export const NoValueString = () => {
 };
 
 export const Value = () => {
-  return <DatePickerButton>{dayjs().format('DD/MM/YYYY')}</DatePickerButton>;
+  return (
+    <DatePickerButton>{formatDate(dayjs(), 'common:short')}</DatePickerButton>
+  );
 };
 
 export const UsageWithPopover = () => {
@@ -48,7 +52,7 @@ export const UsageWithPopover = () => {
       onOpenChange={(open) => datePicker.toggle(open)}
     >
       <PopoverTrigger render={<DatePickerButton />}>
-        {date ? dayjs(date).format('DD/MM/YYYY') : null}
+        {date ? formatDate(date, 'common:short') : null}
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar
@@ -74,12 +78,10 @@ export const UsageWithPopoverRange = () => {
     }
 
     if (isNullish(date?.to)) {
-      return dayjs(date.from).format('DD/MM/YYYY');
+      return formatDate(date.from, 'common:short');
     }
 
-    return `${dayjs(date.from).format(
-      'DD/MM/YYYY'
-    )} - ${dayjs(date.to).format('DD/MM/YYYY')}`;
+    return `${formatDate(date.from, 'common:short')} - ${formatDate(date.to, 'common:short')}`;
   };
 
   return (
@@ -111,7 +113,7 @@ export const UsageWithDialog = () => {
       onOpenChange={(open) => datePicker.toggle(open)}
     >
       <DialogTrigger render={<DatePickerButton />}>
-        {date ? dayjs(date).format('DD/MM/YYYY') : null}
+        {date ? formatDate(date, 'common:short') : null}
       </DialogTrigger>
       <DialogContent className="w-auto" hideCloseButton>
         <DialogBody>

--- a/src/features/booking/request-card.tsx
+++ b/src/features/booking/request-card.tsx
@@ -1,7 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
-import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+
+import { formatDate } from '@/lib/dayjs/formats';
 
 import { orpc } from '@/lib/orpc/client';
 
@@ -79,7 +80,7 @@ export const RequestCard = ({ request }: RequestCardProps) => {
           <CardTitle>{request.passenger.name}</CardTitle>
         </div>
         <CardDescription>
-          {dayjs(request.stop.commute.date).format('DD/MM/YYYY')}
+          {formatDate(request.stop.commute.date, 'booking:requestDate')}
           {' · '}
           {request.stop.outwardTime}
           {request.stop.inwardTime && ` – ${request.stop.inwardTime}`}

--- a/src/features/build-info/script-to-generate-json.ts
+++ b/src/features/build-info/script-to-generate-json.ts
@@ -2,6 +2,8 @@ import dayjs from 'dayjs';
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
 
+import { formatDate } from '@/lib/dayjs/formats';
+
 const getContent = () => {
   const getCommitHashShort = () => {
     try {
@@ -27,7 +29,8 @@ const getContent = () => {
   };
 
   return {
-    display: getCommitHashShort() ?? dayjs().format('YYYY-MM-DD'),
+    display:
+      getCommitHashShort() ?? formatDate(dayjs(), 'buildInfo:fallbackDisplay'),
     version: `${getCommitHashShort() ?? 'No commit'} - ${dayjs().format()}`,
     commit: getCommitHash() ?? 'No commit',
     date: dayjs().format(),

--- a/src/features/commute/card-commute.tsx
+++ b/src/features/commute/card-commute.tsx
@@ -1,7 +1,8 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import dayjs from 'dayjs';
 import { ArrowDownLeft, ArrowUpRight, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+
+import { formatDate } from '@/lib/dayjs/formats';
 
 import { cn } from '@/lib/tailwind/utils';
 
@@ -153,7 +154,7 @@ function CardCommuteHeader({
         <div className="flex flex-col gap-0.5">
           <div className="flex items-center gap-2">
             <CardTitle className="capitalize">
-              {dayjs(date).format('dddd DD/MM')}
+              {formatDate(date, 'commute:dayHeader')}
             </CardTitle>
             <Badge variant="secondary" size="sm">
               {t(`commute:list.type.${type}`)}

--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
+import { formatDate } from '@/lib/dayjs/formats';
 import { orpc } from '@/lib/orpc/client';
 
 import {
@@ -81,7 +82,7 @@ export const PageDashboard = () => {
   // Group commutes by day
   const commutesByDay = new Map<string, CommuteEnriched[]>();
   for (const commute of commutesQuery.data ?? []) {
-    const key = dayjs(commute.date).format('YYYY-MM-DD');
+    const key = formatDate(commute.date, 'common:iso');
     const existing = commutesByDay.get(key) ?? [];
     existing.push(commute);
     commutesByDay.set(key, existing);
@@ -121,7 +122,7 @@ export const PageDashboard = () => {
           .match('default', () => (
             <div className="flex flex-col gap-6">
               {days.map((day) => {
-                const key = day.format('YYYY-MM-DD');
+                const key = formatDate(day, 'common:iso');
                 const isToday = day.isToday();
                 const dayCommutes = commutesByDay.get(key) ?? [];
 
@@ -131,7 +132,7 @@ export const PageDashboard = () => {
                       <h2 className="text-base font-semibold">
                         {isToday
                           ? t('dashboard:today')
-                          : day.format('dddd DD/MM')}
+                          : formatDate(day, 'dashboard:dayHeader')}
                       </h2>
 
                       <OrgButtonLink

--- a/src/features/user/manager/page-user.tsx
+++ b/src/features/user/manager/page-user.tsx
@@ -10,6 +10,8 @@ import { useCanGoBack, useRouter } from '@tanstack/react-router';
 import { Link } from '@tanstack/react-router';
 import dayjs from 'dayjs';
 import { AlertCircleIcon, PencilLineIcon, Trash2Icon } from 'lucide-react';
+
+import { formatDate } from '@/lib/dayjs/formats';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
@@ -211,8 +213,9 @@ export const PageUser = (props: { id: string }) => {
                       {user.onboardedAt ? (
                         <>
                           {t('user:common.onboardingStatus.onboardedAt', {
-                            time: dayjs(user.onboardedAt).format(
-                              'DD/MM/YYYY [at] HH:mm'
+                            time: formatDate(
+                              user.onboardedAt,
+                              'user:onboardedAt'
                             ),
                           })}
                         </>

--- a/src/lib/dayjs/formats.ts
+++ b/src/lib/dayjs/formats.ts
@@ -1,0 +1,73 @@
+import dayjs, { type ConfigType } from 'dayjs';
+
+// ─── Format constants ────────────────────────────────────────────────
+
+const ISO_DATE = 'YYYY-MM-DD';
+const SHORT_DATE = 'DD/MM/YYYY';
+const DAY_NAME_SHORT_DATE = 'dddd D MMM';
+const SHORT_DATE_WITH_TIME = 'DD/MM/YYYY [at] HH:mm';
+
+// ─── Feature-scoped date format definitions ──────────────────────────
+
+const dateFormats = {
+  common: {
+    iso: ISO_DATE,
+    short: SHORT_DATE,
+  },
+  dashboard: {
+    dayHeader: DAY_NAME_SHORT_DATE,
+  },
+  commute: {
+    dayHeader: DAY_NAME_SHORT_DATE,
+  },
+  booking: {
+    requestDate: SHORT_DATE,
+  },
+  user: {
+    onboardedAt: SHORT_DATE_WITH_TIME,
+  },
+  buildInfo: {
+    fallbackDisplay: ISO_DATE,
+  },
+} as const;
+
+export default dateFormats;
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export type DateFormats = typeof dateFormats;
+
+export type DateFormatNamespace = keyof DateFormats;
+
+/** Union of all valid "namespace:key" strings, e.g. 'common:short' | 'dashboard:dayHeader' | ... */
+export type DateFormatKey = {
+  [NS in DateFormatNamespace]: `${NS}:${Extract<keyof DateFormats[NS], string>}`;
+}[DateFormatNamespace];
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Returns the raw Day.js format string for a given date format key.
+ *
+ * Use this when you need the format string itself (not a formatted date),
+ * for example as a `format` prop or placeholder in `DateInput`.
+ *
+ * @example
+ * getDateFormat('common:short')  // => 'DD/MM/YYYY'
+ */
+export function getDateFormat(key: DateFormatKey): string {
+  const [ns, name] = key.split(':') as [DateFormatNamespace, string];
+
+  return (dateFormats as ExplicitAny)[ns][name] as string;
+}
+
+/**
+ * Formats a date value using a feature-scoped date format key.
+ *
+ * @example
+ * formatDate(new Date(), 'dashboard:dayHeader')    // => "lundi 12/05"
+ * formatDate(user.onboardedAt, 'user:onboardedAt') // => "12/05/2025 at 14:30"
+ */
+export function formatDate(date: ConfigType, key: DateFormatKey): string {
+  return dayjs(date).format(getDateFormat(key));
+}

--- a/src/lib/dayjs/parse-string-to-date.unit.spec.ts
+++ b/src/lib/dayjs/parse-string-to-date.unit.spec.ts
@@ -1,10 +1,11 @@
 import dayjs from 'dayjs';
 import { describe, expect, it } from 'vitest';
 
+import { getDateFormat } from '@/lib/dayjs/formats';
 import { parseStringToDate } from '@/lib/dayjs/parse-string-to-date';
 
 describe('parseStringToDate', () => {
-  const FORMAT = 'DD/MM/YYYY';
+  const FORMAT = getDateFormat('common:short');
   it.each([
     { input: '10', expected: dayjs().set('date', 10).format(FORMAT) },
     {


### PR DESCRIPTION
## Summary
- Introduce a `formatDate(date, key)` / `getDateFormat(key)` system in `src/lib/dayjs/formats.ts` mirroring i18n namespaces (`'dashboard:dayHeader'`, `'common:short'`, etc.)
- All date format strings are defined once as named constants (`ISO_DATE`, `SHORT_DATE`, `DAY_NAME_SHORT_DATE`, `SHORT_DATE_WITH_TIME`) and mapped to feature-scoped keys with full TypeScript autocomplete
- Migrate all 10 consumer files to use the new typed API
- Fix bug in `DateInput` where `handleInputBlur` ignored the consumer-provided `format` prop
- Update `DAY_NAME_SHORT_DATE` format to `'dddd D MMM'` (e.g. "Tuesday 17 Feb")

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vitest run src/lib/dayjs/` passes (11 tests)
- [x] No remaining hardcoded format strings (`DATE_FORMAT_*` or inline `'DD/MM/YYYY'`)
- [x] Visual check on dashboard and commute card date headers