### PR TITLE
feat: replace Inter with Public Sans font

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@better-auth/expo": "1.4.17",
     "@better-upload/client": "3.0.12",
     "@better-upload/server": "3.0.12",
-    "@fontsource-variable/inter": "5.2.8",
+    "@fontsource-variable/public-sans": "^5.2.7",
     "@hookform/resolvers": "5.2.2",
     "@orpc/client": "1.13.4",
     "@orpc/openapi": "1.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
       '@better-upload/server':
         specifier: 3.0.12
         version: 3.0.12
-      '@fontsource-variable/inter':
-        specifier: 5.2.8
-        version: 5.2.8
+      '@fontsource-variable/public-sans':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.4))
@@ -1472,8 +1472,8 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@fontsource-variable/inter@5.2.8':
-    resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+  '@fontsource-variable/public-sans@5.2.7':
+    resolution: {integrity: sha512-4mvade2J3slKkvwRkS+p8T3szet/0vhWoSnuUJTVU81Uo2pRpSZY/Y8bSLRqpSwzIPxjVmRJ53oq6JKP/l/PSg==}
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -6817,6 +6817,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -8891,7 +8892,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@fontsource-variable/inter@5.2.8': {}
+  '@fontsource-variable/public-sans@5.2.7': {}
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.4))':
     dependencies:

--- a/src/components/brand/logo.tsx
+++ b/src/components/brand/logo.tsx
@@ -18,7 +18,7 @@ export const Logo = (props: SVGProps<SVGSVGElement>) => (
       fill="currentColor"
       fontSize="32"
       fontWeight="bold"
-      fontFamily="Inter, system-ui, sans-serif"
+      fontFamily="Public Sans, system-ui, sans-serif"
     >
       Cowat
     </text>

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from 'next-themes';
 import type { ReactNode } from 'react';
 import '@/lib/dayjs/config';
 import '@/lib/i18n';
-import '@fontsource-variable/inter';
+import '@fontsource-variable/public-sans';
 
 import { QueryClientProvider } from '@/lib/tanstack-query/provider';
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5,7 +5,7 @@
 
 @theme {
   --font-sans:
-    'Inter Variable', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Public Sans Variable', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --color-*: initial;
   --color-white: #fff;


### PR DESCRIPTION
## Summary
- Replace `@fontsource-variable/inter` with `@fontsource-variable/public-sans`
- Update CSS custom property `--font-sans` to use `Public Sans Variable`
- Update logo SVG font family reference

## Test plan
- [x] Verify the app renders with Public Sans font
- [x] Check logo SVG text renders correctly
- [x] Verify dark mode font rendering