### PR TITLE
feat: commute card badges row & departure times

### DIFF
--- a/src/features/booking/booking-status-badge.tsx
+++ b/src/features/booking/booking-status-badge.tsx
@@ -38,7 +38,7 @@ export const BookingStatusBadge = ({
         }) as React.ComponentProps<typeof Badge>['variant']
       }
       className="uppercase"
-      size="xs"
+      size="sm"
     >
       {t(`booking:request.status.${status}`)}
     </Badge>

--- a/src/features/commute/app/page-commutes.tsx
+++ b/src/features/commute/app/page-commutes.tsx
@@ -155,6 +155,10 @@ export const PageCommutes = () => {
                             ? item.seats - inwardPassengers.size
                             : undefined
                         }
+                        outwardDeparture={item.stops.at(0)?.outwardTime}
+                        inwardDeparture={
+                          item.stops.at(-1)?.inwardTime ?? undefined
+                        }
                         passengers={[...acceptedPassengers.values()]}
                         badge={<BookingStatusBadge status={bookingStatus} />}
                       />

--- a/src/features/commute/card-commute.stories.tsx
+++ b/src/features/commute/card-commute.stories.tsx
@@ -26,6 +26,8 @@ export const Default = () => {
           totalSeats={4}
           outwardAvailable={2}
           inwardAvailable={3}
+          outwardDeparture="08:00"
+          inwardDeparture="17:30"
         />
       </CardCommuteTrigger>
       <CardCommuteContent>
@@ -64,6 +66,8 @@ export const LeftBorderByStatus = () => {
             totalSeats={4}
             outwardAvailable={3}
             inwardAvailable={4}
+            outwardDeparture="07:45"
+            inwardDeparture="18:00"
             badge={<BookingStatusBadge status="DRIVER" />}
           />
         </CardCommuteTrigger>
@@ -80,6 +84,8 @@ export const LeftBorderByStatus = () => {
             totalSeats={4}
             outwardAvailable={3}
             inwardAvailable={3}
+            outwardDeparture="08:00"
+            inwardDeparture="17:30"
             badge={<BookingStatusBadge status="REQUESTED" />}
           />
         </CardCommuteTrigger>
@@ -95,6 +101,7 @@ export const LeftBorderByStatus = () => {
             type="ONEWAY"
             totalSeats={3}
             outwardAvailable={1}
+            outwardDeparture="08:15"
             badge={<BookingStatusBadge status="ACCEPTED" />}
           />
         </CardCommuteTrigger>
@@ -128,6 +135,7 @@ export const LeftBorderByStatus = () => {
             type="ONEWAY"
             totalSeats={2}
             outwardAvailable={0}
+            outwardDeparture="09:00"
             badge={<BookingStatusBadge status="CANCELED" />}
           />
         </CardCommuteTrigger>
@@ -161,6 +169,8 @@ export const WithManyPassengers = () => {
             totalSeats={8}
             outwardAvailable={1}
             inwardAvailable={2}
+            outwardDeparture="07:30"
+            inwardDeparture="18:00"
             passengers={passengers}
             badge={<BookingStatusBadge status="DRIVER" />}
           />
@@ -179,6 +189,7 @@ export const WithManyPassengers = () => {
             type="ONEWAY"
             totalSeats={4}
             outwardAvailable={1}
+            outwardDeparture="08:15"
             passengers={passengers.slice(0, 3)}
             badge={<BookingStatusBadge status="ACCEPTED" />}
           />
@@ -198,6 +209,8 @@ export const WithManyPassengers = () => {
             totalSeats={2}
             outwardAvailable={1}
             inwardAvailable={1}
+            outwardDeparture="08:00"
+            inwardDeparture="17:30"
             passengers={passengers.slice(0, 1)}
             badge={<BookingStatusBadge status="REQUESTED" />}
           />
@@ -221,6 +234,8 @@ export const WithActions = () => {
           totalSeats={4}
           outwardAvailable={2}
           inwardAvailable={3}
+          outwardDeparture="08:00"
+          inwardDeparture="17:30"
           actions={
             <div onClick={(e) => e.stopPropagation()}>
               <Button variant="ghost" size="icon-sm">

--- a/src/features/commute/card-commute.tsx
+++ b/src/features/commute/card-commute.tsx
@@ -1,8 +1,9 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import { ArrowDownLeft, ArrowUpRight, ChevronDown } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { formatDate } from '@/lib/dayjs/formats';
+import { tripTypeIcons } from '@/lib/feature-icons';
 import { cn } from '@/lib/tailwind/utils';
 
 import {
@@ -131,6 +132,8 @@ type CardCommuteHeaderProps = {
   totalSeats: number;
   outwardAvailable: number;
   inwardAvailable?: number;
+  outwardDeparture?: string;
+  inwardDeparture?: string;
   passengers?: Array<{ name?: string | null; image?: string | null }>;
   badge?: React.ReactNode;
   actions?: React.ReactNode;
@@ -145,6 +148,8 @@ function CardCommuteHeader({
   totalSeats,
   outwardAvailable,
   inwardAvailable,
+  outwardDeparture,
+  inwardDeparture,
   passengers,
   badge,
   actions,
@@ -169,49 +174,57 @@ function CardCommuteHeader({
           <CardDescription>{driver.name}</CardDescription>
         </div>
       </div>
+      <CardAction className="row-span-1">
+        <div className="flex items-center gap-1">
+          {actions}
+          <ChevronDown className="chevron-icon size-4 text-muted-foreground transition-transform" />
+        </div>
+      </CardAction>
+      <div className="col-span-full flex items-center gap-2">
+        <Badge variant="secondary" size="sm">
+          {t(`commute:list.type.${type}`)}
+        </Badge>
+        {badge}
+        {!!passengers?.length && (
+          <AvatarGroup className="ml-auto">
+            {passengers.slice(0, MAX_VISIBLE_PASSENGERS).map((p) => (
+              <Avatar key={p.name} size="sm">
+                <AvatarImage src={p.image ?? undefined} />
+                <AvatarFallback variant="boring" name={p.name ?? '?'} />
+              </Avatar>
+            ))}
+            {passengers.length > MAX_VISIBLE_PASSENGERS && (
+              <AvatarGroupCount>
+                +{passengers.length - MAX_VISIBLE_PASSENGERS}
+              </AvatarGroupCount>
+            )}
+          </AvatarGroup>
+        )}
+      </div>
       <div className="col-span-full flex items-center gap-2 text-sm text-muted-foreground">
         {type === 'ROUND' ? (
           <>
             <span className="flex items-center gap-0.5">
-              <ArrowUpRight className="size-3" />
+              <tripTypeIcons.ONEWAY className="size-3" />
+              {outwardDeparture}
+              <span className="text-muted-foreground/60">·</span>
               {seatLabel(outwardAvailable)}
             </span>
             <span className="flex items-center gap-0.5">
-              <ArrowDownLeft className="size-3" />
+              <tripTypeIcons.RETURN className="size-3" />
+              {inwardDeparture}
+              <span className="text-muted-foreground/60">·</span>
               {seatLabel(inwardAvailable ?? outwardAvailable)}
             </span>
           </>
         ) : (
-          <span>{seatLabel(outwardAvailable)}</span>
+          <span className="flex items-center gap-0.5">
+            {outwardDeparture}
+            <span className="text-muted-foreground/60">·</span>
+            {seatLabel(outwardAvailable)}
+          </span>
         )}
-        <Badge variant="secondary" size="sm">
-          {t(`commute:list.type.${type}`)}
-        </Badge>
       </div>
-      <CardAction>
-        <div className="flex flex-col items-end gap-1">
-          <div className="flex items-center gap-1">
-            {badge}
-            {actions}
-            <ChevronDown className="chevron-icon size-4 text-muted-foreground transition-transform" />
-          </div>
-          {!!passengers?.length && (
-            <AvatarGroup>
-              {passengers.slice(0, MAX_VISIBLE_PASSENGERS).map((p) => (
-                <Avatar key={p.name} size="sm">
-                  <AvatarImage src={p.image ?? undefined} />
-                  <AvatarFallback variant="boring" name={p.name ?? '?'} />
-                </Avatar>
-              ))}
-              {passengers.length > MAX_VISIBLE_PASSENGERS && (
-                <AvatarGroupCount>
-                  +{passengers.length - MAX_VISIBLE_PASSENGERS}
-                </AvatarGroupCount>
-              )}
-            </AvatarGroup>
-          )}
-        </div>
-      </CardAction>
     </>
   );
 }

--- a/src/features/commute/stops-timeline.tsx
+++ b/src/features/commute/stops-timeline.tsx
@@ -1,4 +1,3 @@
-import { ArrowDownLeft, ArrowUpRight } from 'lucide-react';
 import { ReactNode } from 'react';
 
 import { tripTypeIcons } from '@/lib/feature-icons';
@@ -39,12 +38,12 @@ export const StopsTimelineItem = ({
       </span>
       <div className="flex items-center gap-3 text-sm text-muted-foreground">
         <span className="flex items-center gap-1">
-          <ArrowUpRight className="size-3.5" />
+          <tripTypeIcons.ONEWAY className="size-3.5" />
           {stop.outwardTime}
         </span>
         {stop.inwardTime && (
           <span className="flex items-center gap-1">
-            <ArrowDownLeft className="size-3.5" />
+            <tripTypeIcons.RETURN className="size-3.5" />
             {stop.inwardTime}
           </span>
         )}

--- a/src/features/dashboard/dashboard-commute-card.tsx
+++ b/src/features/dashboard/dashboard-commute-card.tsx
@@ -15,10 +15,7 @@ import {
 import { CardCommuteActions } from '@/features/commute/card-commute-actions';
 import { CardCommuteStopsList } from '@/features/commute/card-commute-stops-list';
 import { getCommutePassengerStats } from '@/features/commute/commute-passengers';
-import {
-  CommuteEnriched,
-  type CommuteType,
-} from '@/features/commute/schema';
+import { CommuteEnriched, type CommuteType } from '@/features/commute/schema';
 
 type DashboardCommuteCardProps = {
   commute: CommuteEnriched;
@@ -73,6 +70,8 @@ export const DashboardCommuteCard = ({
               ? commute.seats - inwardPassengers.size
               : undefined
           }
+          outwardDeparture={commute.stops.at(0)?.outwardTime}
+          inwardDeparture={commute.stops.at(-1)?.inwardTime ?? undefined}
           passengers={[...acceptedPassengers.values()]}
           badge={bookingStatus && <BookingStatusBadge status={bookingStatus} />}
         />


### PR DESCRIPTION
## Summary
- Move booking status and trip type badges to a dedicated row between the driver avatar/title and passenger avatars in the commute card header
- Add outbound/inbound departure times alongside seat counts in the info row
- Replace hardcoded `ArrowUpRight`/`ArrowDownLeft` lucide imports with `tripTypeIcons` from `feature-icons.ts` in both `card-commute.tsx` and `stops-timeline.tsx`

## Test plan
- [x] Verify commute cards on the dashboard display badges (booking status + trip type) on their own row between the title and passengers
- [x] Verify departure times appear next to seat counts (e.g. `↗ 08:00 · 2/4 places`)
- [x] Verify ONEWAY commutes show only outbound time, ROUND commutes show both
- [x] Verify Storybook stories render correctly with the new layout