### PR TITLE
feat: improve empty states

### DIFF
--- a/src/features/booking/app/page-requests.tsx
+++ b/src/features/booking/app/page-requests.tsx
@@ -1,8 +1,8 @@
 import { getUiState } from '@bearstudio/ui-state';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { InboxIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { featureIcons } from '@/lib/feature-icons';
 import { orpc } from '@/lib/orpc/client';
 
 import { Button } from '@/components/ui/button';
@@ -64,7 +64,7 @@ export const PageRequests = () => {
             <Empty>
               <EmptyHeader>
                 <EmptyMedia variant="icon">
-                  <InboxIcon />
+                  <featureIcons.Bookings />
                 </EmptyMedia>
                 <EmptyTitle>{t('booking:requests.emptyState')}</EmptyTitle>
               </EmptyHeader>

--- a/src/features/commute-template/app/page-commute-templates.tsx
+++ b/src/features/commute-template/app/page-commute-templates.tsx
@@ -5,6 +5,7 @@ import { PlusIcon, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
+import { BackButton } from '@/components/back-button';
 import { featureIcons } from '@/lib/feature-icons';
 import { orpc } from '@/lib/orpc/client';
 
@@ -17,6 +18,7 @@ import {
 } from '@/components/ui/datalist';
 import {
   Empty,
+  EmptyContent,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
@@ -25,7 +27,10 @@ import { ResponsiveIconButton } from '@/components/ui/responsive-icon-button';
 
 import { CardCommuteStopsList } from '@/features/commute/card-commute-stops-list';
 import { CardCommuteTemplateHeader } from '@/features/commute-template/card-commute-template-header';
-import { OrgResponsiveIconButtonLink } from '@/features/organization/org-button-link';
+import {
+  OrgButtonLink,
+  OrgResponsiveIconButtonLink,
+} from '@/features/organization/org-button-link';
 import {
   PageLayout,
   PageLayoutContent,
@@ -71,6 +76,7 @@ export const PageCommuteTemplates = ({ orgSlug }: { orgSlug: string }) => {
   return (
     <PageLayout>
       <PageLayoutTopBar
+        startActions={<BackButton />}
         endActions={
           <OrgResponsiveIconButtonLink
             label={t('commuteTemplate:list.newAction')}
@@ -100,6 +106,16 @@ export const PageCommuteTemplates = ({ orgSlug }: { orgSlug: string }) => {
                 </EmptyMedia>
                 <EmptyTitle>{t('commuteTemplate:list.emptyState')}</EmptyTitle>
               </EmptyHeader>
+              <EmptyContent>
+                <OrgButtonLink
+                  variant="secondary"
+                  size="sm"
+                  to="/app/$orgSlug/account/commute-templates/new"
+                >
+                  <PlusIcon />
+                  {t('commuteTemplate:list.newAction')}
+                </OrgButtonLink>
+              </EmptyContent>
             </Empty>
           ))
           .match('default', ({ items }) => (

--- a/src/features/commute/app/page-commutes.tsx
+++ b/src/features/commute/app/page-commutes.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/datalist';
 import {
   Empty,
+  EmptyContent,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
@@ -31,7 +32,10 @@ import {
 import { CardCommuteActions } from '@/features/commute/card-commute-actions';
 import { CardCommuteStopsList } from '@/features/commute/card-commute-stops-list';
 import { getCommutePassengerStats } from '@/features/commute/commute-passenger-rules';
-import { OrgResponsiveIconButtonLink } from '@/features/organization/org-button-link';
+import {
+  OrgButtonLink,
+  OrgResponsiveIconButtonLink,
+} from '@/features/organization/org-button-link';
 import {
   PageLayout,
   PageLayoutContent,
@@ -127,6 +131,16 @@ export const PageCommutes = () => {
                 </EmptyMedia>
                 <EmptyTitle>{t('commute:list.emptyState')}</EmptyTitle>
               </EmptyHeader>
+              <EmptyContent>
+                <OrgButtonLink
+                  variant="secondary"
+                  size="sm"
+                  to="/app/$orgSlug/commutes/new"
+                >
+                  <PlusIcon />
+                  {t('commute:list.newAction')}
+                </OrgButtonLink>
+              </EmptyContent>
             </Empty>
           ))
           .match('default', ({ items }) => (

--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -1,7 +1,9 @@
 import { getUiState } from '@bearstudio/ui-state';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
-import { CalendarIcon, PlusIcon } from 'lucide-react';
+import { PlusIcon } from 'lucide-react';
+
+import { featureIcons } from '@/lib/feature-icons';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -15,6 +17,7 @@ import {
 } from '@/components/ui/datalist';
 import {
   Empty,
+  EmptyContent,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
@@ -153,15 +156,26 @@ export const PageDashboard = () => {
                     </div>
 
                     {dayCommutes.length === 0 ? (
-                      <Empty className="p-6">
+                      <Empty className="border p-4">
                         <EmptyHeader>
                           <EmptyMedia variant="icon">
-                            <CalendarIcon />
+                            <featureIcons.Commutes />
                           </EmptyMedia>
                           <EmptyTitle className="text-sm">
                             {t('dashboard:noCommutesForDay')}
                           </EmptyTitle>
                         </EmptyHeader>
+                        <EmptyContent>
+                          <OrgButtonLink
+                            to="/app/$orgSlug/commutes/new"
+                            search={{ date: day.toDate() }}
+                            variant="secondary"
+                            size="sm"
+                          >
+                            <PlusIcon />
+                            {t('dashboard:newCommuteAction')}
+                          </OrgButtonLink>
+                        </EmptyContent>
                       </Empty>
                     ) : (
                       <div className="flex flex-col gap-3">

--- a/src/features/location/app/page-locations.tsx
+++ b/src/features/location/app/page-locations.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
+import { BackButton } from '@/components/back-button';
 import { featureIcons } from '@/lib/feature-icons';
 import { orpc } from '@/lib/orpc/client';
 
@@ -20,6 +21,7 @@ import {
 } from '@/components/ui/datalist';
 import {
   Empty,
+  EmptyContent,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
@@ -85,6 +87,7 @@ export const PageLocations = () => {
   return (
     <PageLayout>
       <PageLayoutTopBar
+        startActions={<BackButton />}
         endActions={
           <ResponsiveIconButton
             label={t('location:list.newAction')}
@@ -114,6 +117,16 @@ export const PageLocations = () => {
                 </EmptyMedia>
                 <EmptyTitle>{t('location:list.emptyState')}</EmptyTitle>
               </EmptyHeader>
+              <EmptyContent>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={openCreateDrawer}
+                >
+                  <PlusIcon />
+                  {t('location:list.newAction')}
+                </Button>
+              </EmptyContent>
             </Empty>
           ))
           .match('default', ({ items }) => (

--- a/src/lib/feature-icons.ts
+++ b/src/lib/feature-icons.ts
@@ -1,16 +1,18 @@
 import {
   ArrowDownLeft,
   ArrowUpRight,
-  CarIcon,
+  InboxIcon,
   MapPinIcon,
   Repeat,
   RouteIcon,
 } from 'lucide-react';
 
+import { IconCarDuotone } from '@/components/icons/generated';
 export const featureIcons = {
   Locations: MapPinIcon,
   CommuteTemplates: RouteIcon,
-  Commutes: CarIcon,
+  Commutes: IconCarDuotone,
+  Bookings: InboxIcon,
 } as const;
 
 export const tripTypeIcons = {


### PR DESCRIPTION
## Summary
- Add CTA buttons to all empty states (dashboard day, locations, commutes, commute templates) linking to their respective creation actions
- Add dashed border and reduce padding on the dashboard empty day commute
- Replace raw lucide icons with centralized `featureIcons` in dashboard and booking requests empty states
- Add `Bookings` entry to `featureIcons`
- Add back button to commute templates and locations pages

## Test plan
- [x] Verify each empty state displays correctly with CTA button and feature icon
- [x] Verify dashboard empty day has dashed border and reduced height
- [x] Verify CTA buttons navigate to the correct creation flows
- [x] Verify back buttons work on locations and commute templates pages