### PR TITLE
feat: dayjs.f() plugin for feature-scoped date formatting

### DIFF
--- a/src/components/ui/calendar.stories.tsx
+++ b/src/components/ui/calendar.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta } from '@storybook/react-vite';
 import dayjs from 'dayjs';
 import { useState } from 'react';
-
 import '@/lib/dayjs/config';
 
 import { Calendar } from '@/components/ui/calendar';

--- a/src/components/ui/date-input.tsx
+++ b/src/components/ui/date-input.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from 'react';
 
-import { getFormat } from '@/lib/dayjs/formats';
+import { getDateFormat } from '@/lib/dayjs/formats';
 import { parseStringToDate } from '@/lib/dayjs/parse-string-to-date';
 import { toNoonUTC } from '@/lib/dayjs/to-noon-utc';
 
@@ -89,7 +89,7 @@ export const DateInput = ({
   onBlur,
   onKeyDown,
   value,
-  format = getFormat('common:short'),
+  format = getDateFormat('common:short'),
   ...props
 }: Omit<ComponentProps<typeof Input>, 'onChange' | 'value'> & {
   onChange?: (date: Date | null) => void;

--- a/src/components/ui/date-picker-button.stories.tsx
+++ b/src/components/ui/date-picker-button.stories.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { DateRange } from 'react-day-picker';
 import { useDisclosure } from 'react-use-disclosure';
 import { isNullish } from 'remeda';
-
 import '@/lib/dayjs/config';
 
 import { Calendar } from '@/components/ui/calendar';

--- a/src/features/booking/request-card.tsx
+++ b/src/features/booking/request-card.tsx
@@ -1,10 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
+import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-
-import dayjs from 'dayjs';
-
 import '@/lib/dayjs/config';
+
 import { orpc } from '@/lib/orpc/client';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';

--- a/src/features/build-info/script-to-generate-json.ts
+++ b/src/features/build-info/script-to-generate-json.ts
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
-
 import '@/lib/dayjs/config';
 
 const getContent = () => {

--- a/src/features/commute/card-commute.tsx
+++ b/src/features/commute/card-commute.tsx
@@ -1,10 +1,9 @@
 import { cva, type VariantProps } from 'class-variance-authority';
+import dayjs from 'dayjs';
 import { ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-
-import dayjs from 'dayjs';
-
 import '@/lib/dayjs/config';
+
 import { tripTypeIcons } from '@/lib/feature-icons';
 import { cn } from '@/lib/tailwind/utils';
 

--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -5,8 +5,8 @@ import { PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-
 import '@/lib/dayjs/config';
+
 import { featureIcons } from '@/lib/feature-icons';
 import { orpc } from '@/lib/orpc/client';
 

--- a/src/lib/dayjs/formats.ts
+++ b/src/lib/dayjs/formats.ts
@@ -46,7 +46,7 @@ export type DateFormatKey = FormatKey<DateFormats>;
 
 // ─── Plugin instance & helpers ───────────────────────────────────────
 
-export const { plugin: formatPlugin, getFormat } =
+export const { plugin: formatPlugin, getDateFormat } =
   createFormatPlugin(dateFormats);
 
 // ─── Type augmentation ───────────────────────────────────────────────

--- a/src/lib/dayjs/parse-string-to-date.unit.spec.ts
+++ b/src/lib/dayjs/parse-string-to-date.unit.spec.ts
@@ -1,11 +1,11 @@
 import dayjs from 'dayjs';
 import { describe, expect, it } from 'vitest';
 
-import { getFormat } from '@/lib/dayjs/formats';
+import { getDateFormat } from '@/lib/dayjs/formats';
 import { parseStringToDate } from '@/lib/dayjs/parse-string-to-date';
 
 describe('parseStringToDate', () => {
-  const FORMAT = getFormat('common:short');
+  const FORMAT = getDateFormat('common:short');
   it.each([
     { input: '10', expected: dayjs().set('date', 10).format(FORMAT) },
     {

--- a/src/lib/dayjs/plugins/format.ts
+++ b/src/lib/dayjs/plugins/format.ts
@@ -19,7 +19,7 @@ export type FormatKey<T extends FormatConfig> = {
  * feature-scoped date formatting.
  *
  * @example
- * const { plugin, getFormat } = createFormatPlugin({
+ * const { plugin, getDateFormat } = createFormatPlugin({
  *   common: { iso: 'YYYY-MM-DD', short: 'DD/MM/YYYY' },
  * } as const);
  *
@@ -27,7 +27,7 @@ export type FormatKey<T extends FormatConfig> = {
  * dayjs().f('common:short'); // => '20/02/2026'
  */
 export function createFormatPlugin<const T extends FormatConfig>(config: T) {
-  function getFormat(key: FormatKey<T>): string {
+  function getDateFormat(key: FormatKey<T>): string {
     const [ns, name] = key.split(':') as [string, string];
     return (config as FormatConfig)[ns]![name]!;
   }
@@ -36,9 +36,9 @@ export function createFormatPlugin<const T extends FormatConfig>(config: T) {
     // Type safety for callers is enforced by the consumer's `declare module 'dayjs'` augmentation.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     dayjsClass.prototype.f = function (key: any) {
-      return this.format(getFormat(key));
+      return this.format(getDateFormat(key));
     };
   };
 
-  return { plugin, getFormat };
+  return { plugin, getDateFormat };
 }


### PR DESCRIPTION
## Summary

- Introduces a generic `createFormatPlugin<T>(config)` factory in `src/lib/dayjs/plugins/format.ts` — fully extractable as a standalone lib
- App-specific format definitions, types, and `declare module 'dayjs'` augmentation live in `src/lib/dayjs/formats.ts`
- Migrates all `formatDate(date, key)` call sites to the new `dayjs(date).f(key)` instance method
- Replaces `getDateFormat(key)` with `getFormat(key)` exported from `formats.ts`

## Test plan

- [ ] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] `parse-string-to-date` unit tests pass
- [ ] Verify date formatting renders correctly on dashboard, commute cards, booking requests, and user detail pages
- [ ] Verify `DateInput` default format prop still resolves to `DD/MM/YYYY`