### PR TITLE
fix: redirect admin to app root instead of /manager on login

### DIFF
--- a/src/features/auth/utils.ts
+++ b/src/features/auth/utils.ts
@@ -40,21 +40,6 @@ export const useRedirectAfterLogin = () => {
         authClient.admin.checkRolePermission({
           role: userRole as Role,
           permission: {
-            apps: ['manager'],
-          },
-        })
-      ) {
-        router.navigate({
-          replace: true,
-          to: '/manager',
-        });
-        return;
-      }
-
-      if (
-        authClient.admin.checkRolePermission({
-          role: userRole as Role,
-          permission: {
             apps: ['app'],
           },
         })


### PR DESCRIPTION
Fixes #80

## Summary
- Removes the special-case logic in `useRedirectAfterLogin` that redirected admin users to `/manager` after login
- Admins now follow the same redirect path as regular users: `/app` if they have app permission, otherwise `/`

## Test plan
- [x] Log in as an admin user and verify you are redirected to `/app` (not `/manager`)
- [x] Log in as a regular user and verify redirect still goes to `/app`
- [x] Verify the `/manager` route is still accessible by navigating directly