### PR TITLE
fix: redirect admin to /app instead of /manager on login

### DIFF
--- a/src/features/auth/utils.ts
+++ b/src/features/auth/utils.ts
@@ -40,21 +40,6 @@ export const useRedirectAfterLogin = () => {
         authClient.admin.checkRolePermission({
           role: userRole as Role,
           permission: {
-            apps: ['manager'],
-          },
-        })
-      ) {
-        router.navigate({
-          replace: true,
-          to: '/manager',
-        });
-        return;
-      }
-
-      if (
-        authClient.admin.checkRolePermission({
-          role: userRole as Role,
-          permission: {
             apps: ['app'],
           },
         })


### PR DESCRIPTION
## Summary
- Admins were being redirected to `/manager` after logging in
- They should land in the main app (`/app`) like regular users, and navigate to `/manager` manually if needed
- Removed the `apps: ['manager']` permission check that caused the early redirect

Closes #80