### PR TITLE
chore: remove GitHub OAuth code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,10 +37,6 @@ AUTH_SESSION_EXPIRATION_IN_SECONDS=2592000 # 30 days
 AUTH_SESSION_UPDATE_AGE_IN_SECONDS=86400 # 1 day (every 1 day the session expiration is updated)
 AUTH_TRUSTED_ORIGINS="cowat-native://,cowat-native://*" # Mobile app scheme for trustedOrigins config
 
-# GITHUB
-GITHUB_CLIENT_ID="REPLACE ME"
-GITHUB_CLIENT_SECRET="REPLACE ME"
-
 # EMAILS
 EMAIL_SERVER="smtp://username:password@0.0.0.0:1025"
 EMAIL_FROM="Cowat <noreply@example.com>"

--- a/src/env/server.ts
+++ b/src/env/server.ts
@@ -20,9 +20,6 @@ export const envServer = createEnv({
       .optional()
       .transform((stringValue) => stringValue?.split(',').map((v) => v.trim())),
 
-    GITHUB_CLIENT_ID: zOptionalWithReplaceMe(),
-    GITHUB_CLIENT_SECRET: zOptionalWithReplaceMe(),
-
     SLACK_BOT_TOKEN: zOptionalWithReplaceMe(),
     SLACK_DEFAULT_CHANNEL: zOptionalWithReplaceMe(),
     SLACK_LOCALE: z.enum(['en', 'fr']).default('en'),

--- a/src/features/auth/page-login.tsx
+++ b/src/features/auth/page-login.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -30,30 +29,6 @@ export default function PageLogin({
 }) {
   const { t } = useTranslation(['auth', 'common']);
   const router = useRouter();
-  const social = useMutation({
-    mutationFn: async (
-      provider: Parameters<typeof authClient.signIn.social>[0]['provider']
-    ) => {
-      try {
-        const response = await authClient.signIn.social({
-          provider,
-          callbackURL: search.redirect ?? '/',
-          errorCallbackURL: '/login/error',
-        });
-        if (response.error) {
-          throw new Error(response.error.message);
-        }
-        return response.data;
-      } catch {
-        toast.error(t('auth:errorCode.UNKNOWN_ERROR'));
-      }
-    },
-    onError: (error) => {
-      form.setError('email', { message: error.message });
-      toast.error(error.message);
-    },
-  });
-
   const form = useForm({
     mode: 'onSubmit',
     resolver: zodResolver(zFormFieldsLogin()),
@@ -130,23 +105,6 @@ export default function PageLogin({
           </Button>
           <LoginEmailHint />
         </div>
-        <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
-          <span className="relative z-10 bg-background px-2 text-muted-foreground">
-            {t(`${I18N_KEY_PAGE_PREFIX}.spacer`)}
-          </span>
-        </div>
-        <Button
-          className="w-full"
-          variant="secondary"
-          loading={
-            social.variables === 'github' &&
-            (social.isPending || social.isSuccess)
-          }
-          size="lg"
-          onClick={() => social.mutate('github')}
-        >
-          {t(`${I18N_KEY_PAGE_PREFIX}.loginWithSocial`, { provider: 'GitHub' })}
-        </Button>
       </div>
     </Form>
   );

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -10,16 +10,12 @@
   "pageLogin": {
     "title": "Login to your account",
     "description": "Enter your email to login to your account",
-    "spacer": "OR",
-    "loginWithEmail": "Login with email",
-    "loginWithSocial": "Login with {{provider}}"
+    "loginWithEmail": "Login with email"
   },
   "pageLoginWithSignUp": {
     "title": "Login or Sign Up",
     "description": "Enter your email to login or create an account",
-    "spacer": "OR",
-    "loginWithEmail": "Continue with email",
-    "loginWithSocial": "Continue with {{provider}}"
+    "loginWithEmail": "Continue with email"
   },
   "pageLoginVerify": {
     "title": "Verification",

--- a/src/locales/fr/auth.json
+++ b/src/locales/fr/auth.json
@@ -2,15 +2,11 @@
   "pageLogin": {
     "title": "Connexion à votre compte",
     "description": "Entrez votre email ci-dessous pour vous connecter à votre compte",
-    "spacer": "Ou continuez avec",
-    "loginWithEmail": "Connexion avec email",
-    "loginWithSocial": "Connexion avec {{provider}}"
+    "loginWithEmail": "Connexion avec email"
   },
   "pageLoginWithSignUp": {
     "description": "Entrez votre email pour vous connecter ou créer un compte",
     "loginWithEmail": "Continuez avec email",
-    "loginWithSocial": "Continuez avec {{provider}}",
-    "spacer": "OU",
     "title": "Connexion ou Inscription"
   },
   "pageLoginVerify": {

--- a/src/server/auth.tsx
+++ b/src/server/auth.tsx
@@ -70,15 +70,6 @@ export const auth = betterAuth({
     throw: true,
     errorURL: '/login/error',
   },
-  socialProviders: {
-    github: {
-      enabled: !!(envServer.GITHUB_CLIENT_ID && envServer.GITHUB_CLIENT_SECRET),
-      clientId: envServer.GITHUB_CLIENT_ID!,
-      clientSecret: envServer.GITHUB_CLIENT_SECRET!,
-      disableImplicitSignUp: !AUTH_SIGNUP_ENABLED,
-    },
-  },
-
   plugins: [
     expo(), // Allows an Expo native app to use auth, can be delete if no needed
     openAPI({


### PR DESCRIPTION
## Summary

- Remove `socialProviders.github` configuration from `auth.tsx`
- Remove `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` from env schema and `.env.example`
- Remove GitHub sign-in button, divider, and `social` mutation from login page
- Remove unused `spacer` and `loginWithSocial` i18n keys from `en` and `fr` locale files

Closes #83