### PR TITLE
feat: add date range filters to stats dashboard

### DIFF
--- a/src/features/stats/manager/page-stats.tsx
+++ b/src/features/stats/manager/page-stats.tsx
@@ -1,10 +1,12 @@
 import { getUiState } from '@bearstudio/ui-state';
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { orpc } from '@/lib/orpc/client';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
 import {
   Card,
   CardContent,
@@ -22,6 +24,7 @@ import {
   DataListText,
   DataListTextHeader,
 } from '@/components/ui/datalist';
+import { DatePicker } from '@/components/ui/date-picker';
 
 import { RankingCard } from '@/features/stats/manager/ranking-card';
 import {
@@ -34,7 +37,17 @@ import {
 export const PageStats = () => {
   const { t } = useTranslation(['stats']);
 
-  const statsQuery = useQuery(orpc.stats.getAll.queryOptions());
+  const [from, setFrom] = useState<Date | null>(null);
+  const [to, setTo] = useState<Date | null>(null);
+
+  const statsQuery = useQuery(
+    orpc.stats.getAll.queryOptions({
+      input:
+        from || to
+          ? { from: from ?? undefined, to: to ?? undefined }
+          : undefined,
+    })
+  );
 
   const ui = getUiState((set) => {
     if (statsQuery.status === 'pending') return set('pending');
@@ -51,6 +64,32 @@ export const PageStats = () => {
           {t('stats:manager.title')}
         </PageLayoutTopBarTitle>
       </PageLayoutTopBar>
+      <div className="flex flex-wrap items-center gap-3 px-4 py-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">
+            {t('stats:manager.filters.from')}
+          </span>
+          <DatePicker value={from} onChange={setFrom} noCalendar={false} />
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">
+            {t('stats:manager.filters.to')}
+          </span>
+          <DatePicker value={to} onChange={setTo} noCalendar={false} />
+        </div>
+        {(from || to) && (
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              setFrom(null);
+              setTo(null);
+            }}
+          >
+            {t('stats:manager.filters.reset')}
+          </Button>
+        )}
+      </div>
       <PageLayoutContent className="pb-20">
         {ui
           .match('pending', () => (

--- a/src/locales/en/stats.json
+++ b/src/locales/en/stats.json
@@ -11,6 +11,11 @@
       "mostStops": "Most Stops",
       "mostStopsDescription": "Most stops across commutes"
     },
+    "filters": {
+      "from": "From",
+      "to": "To",
+      "reset": "Reset filters"
+    },
     "table": {
       "title": "All Users",
       "description": "Overview of all users and their activity",

--- a/src/locales/fr/stats.json
+++ b/src/locales/fr/stats.json
@@ -11,6 +11,11 @@
       "mostStops": "Plus d'arrêts",
       "mostStopsDescription": "Plus d'arrêts sur les trajets"
     },
+    "filters": {
+      "from": "Du",
+      "to": "Au",
+      "reset": "Réinitialiser les filtres"
+    },
     "table": {
       "title": "Tous les utilisateurs",
       "description": "Vue d'ensemble de tous les utilisateurs et leur activité",

--- a/src/server/repositories/stats.repository.ts
+++ b/src/server/repositories/stats.repository.ts
@@ -1,8 +1,15 @@
 import type { AppDB } from '@/server/db';
 
+type DateRange = { from?: Date; to?: Date };
+
 export const createStatsRepository = (db: AppDB) => ({
-  getMembersWithCounts: (organizationId: string) =>
-    db.member.findMany({
+  getMembersWithCounts: (organizationId: string, dateRange?: DateRange) => {
+    const dateFilter =
+      dateRange?.from || dateRange?.to
+        ? { gte: dateRange.from, lt: dateRange.to }
+        : undefined;
+
+    return db.member.findMany({
       where: { organizationId },
       include: {
         user: {
@@ -10,20 +17,36 @@ export const createStatsRepository = (db: AppDB) => ({
         },
         _count: {
           select: {
-            drivenCommutes: true,
-            passengerBookings: true,
+            drivenCommutes: dateFilter ? { where: { date: dateFilter } } : true,
+            passengerBookings: dateFilter
+              ? {
+                  where: {
+                    stop: { commute: { date: dateFilter } },
+                  },
+                }
+              : true,
             drivenTemplates: true,
           },
         },
       },
-    }),
+    });
+  },
 
-  getCommuteStopCounts: (organizationId: string) =>
-    db.commute.findMany({
-      where: { driver: { organizationId } },
+  getCommuteStopCounts: (organizationId: string, dateRange?: DateRange) => {
+    const dateFilter =
+      dateRange?.from || dateRange?.to
+        ? { gte: dateRange.from, lt: dateRange.to }
+        : undefined;
+
+    return db.commute.findMany({
+      where: {
+        driver: { organizationId },
+        ...(dateFilter ? { date: dateFilter } : {}),
+      },
       select: {
         driverMemberId: true,
         _count: { select: { stops: true } },
       },
-    }),
+    });
+  },
 });

--- a/src/server/routers/stats.ts
+++ b/src/server/routers/stats.ts
@@ -17,13 +17,23 @@ const procedure = (args: OrganizationProcedureArgs = {}) =>
 export default {
   getAll: procedure()
     .route({ method: 'GET', path: '/stats', tags })
+    .input(
+      z
+        .object({
+          from: z.coerce.date().optional(),
+          to: z.coerce.date().optional(),
+        })
+        .optional()
+    )
     .output(z.object({ users: z.array(zStatsUser()) }))
-    .handler(async ({ context }) => {
+    .handler(async ({ context, input }) => {
       context.logger.info('Getting stats from database');
 
+      const dateRange = input?.from || input?.to ? input : undefined;
+
       const [membersWithCounts, commutesWithStops] = await Promise.all([
-        context.stats.getMembersWithCounts(context.organizationId),
-        context.stats.getCommuteStopCounts(context.organizationId),
+        context.stats.getMembersWithCounts(context.organizationId, dateRange),
+        context.stats.getCommuteStopCounts(context.organizationId, dateRange),
       ]);
 
       const stopCountByMember = new Map<string, number>();

--- a/src/server/routers/stats.unit.spec.ts
+++ b/src/server/routers/stats.unit.spec.ts
@@ -59,6 +59,37 @@ describe('stats router', () => {
       );
     });
 
+    it('should apply date range filter to commute counts when from/to are provided', async () => {
+      mockDb.member.findMany.mockResolvedValue([]);
+      mockDb.commute.findMany.mockResolvedValue([]);
+
+      const from = new Date('2025-01-01');
+      const to = new Date('2025-12-31');
+
+      await call(statsRouter.getAll, { from, to });
+
+      expect(mockDb.commute.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            date: { gte: from, lt: to },
+          }),
+        })
+      );
+    });
+
+    it('should not apply date filter when no date range is provided', async () => {
+      mockDb.member.findMany.mockResolvedValue([]);
+      mockDb.commute.findMany.mockResolvedValue([]);
+
+      await call(statsRouter.getAll, undefined);
+
+      expect(mockDb.commute.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { driver: { organizationId: mockOrganizationId } },
+        })
+      );
+    });
+
     it('should include user info and relation counts on member', async () => {
       mockDb.member.findMany.mockResolvedValue([]);
       mockDb.commute.findMany.mockResolvedValue([]);


### PR DESCRIPTION
Closes #79

## Summary
- Added optional `from`/`to` date inputs to the `stats.getAll` endpoint
- Repository methods filter commute counts, booking counts, and stop counts by date range; template counts remain all-time
- Stats page now shows two date pickers (From / To) above the content, with a small reset button that appears when any filter is active

## Test plan
- [ ] Select a "From" date and verify commute/booking/stop counts update
- [ ] Select a "To" date and verify counts update
- [ ] Select both dates and verify filtering works as expected
- [ ] Click "Reset filters" and verify counts return to all-time values
- [ ] Verify template counts are unaffected by date filters
- [ ] Run `vitest run src/server/routers/stats.unit.spec.ts` — all 8 tests pass