### PR TITLE
feat: improve Slack message templates

### DIFF
--- a/src/features/slack/templates/booking-accepted.ts
+++ b/src/features/slack/templates/booking-accepted.ts
@@ -3,6 +3,7 @@ import type { LanguageKey } from '@/lib/i18n/constants';
 import type { BookingAcceptedEvent } from '@/server/notifications/types';
 
 import {
+  contextBlock,
   formatDate,
   localizeTripType,
   type SlackBlock,
@@ -18,9 +19,13 @@ export function bookingAccepted(
     textBlock(
       t(locale, 'booking.accepted', {
         driverName: event.payload.driverName,
-        tripType: localizeTripType(locale, event.payload.tripType),
-        date: formatDate(event.payload.commuteDate, locale),
       })
     ),
+    contextBlock([
+      t(locale, 'booking.acceptedContext', {
+        date: formatDate(event.payload.commuteDate, locale),
+        tripType: localizeTripType(locale, event.payload.tripType),
+      }),
+    ]),
   ];
 }

--- a/src/features/slack/templates/booking-canceled.ts
+++ b/src/features/slack/templates/booking-canceled.ts
@@ -3,6 +3,7 @@ import type { LanguageKey } from '@/lib/i18n/constants';
 import type { BookingCanceledEvent } from '@/server/notifications/types';
 
 import {
+  contextBlock,
   formatDate,
   localizeTripType,
   type SlackBlock,
@@ -18,9 +19,13 @@ export function bookingCanceled(
     textBlock(
       t(locale, 'booking.canceled', {
         passengerName: event.payload.passengerName,
-        tripType: localizeTripType(locale, event.payload.tripType),
-        date: formatDate(event.payload.commuteDate, locale),
       })
     ),
+    contextBlock([
+      t(locale, 'booking.canceledContext', {
+        date: formatDate(event.payload.commuteDate, locale),
+        tripType: localizeTripType(locale, event.payload.tripType),
+      }),
+    ]),
   ];
 }

--- a/src/features/slack/templates/booking-refused.ts
+++ b/src/features/slack/templates/booking-refused.ts
@@ -3,6 +3,7 @@ import type { LanguageKey } from '@/lib/i18n/constants';
 import type { BookingRefusedEvent } from '@/server/notifications/types';
 
 import {
+  contextBlock,
   formatDate,
   localizeTripType,
   type SlackBlock,
@@ -18,9 +19,13 @@ export function bookingRefused(
     textBlock(
       t(locale, 'booking.refused', {
         driverName: event.payload.driverName,
-        tripType: localizeTripType(locale, event.payload.tripType),
-        date: formatDate(event.payload.commuteDate, locale),
       })
     ),
+    contextBlock([
+      t(locale, 'booking.refusedContext', {
+        date: formatDate(event.payload.commuteDate, locale),
+        tripType: localizeTripType(locale, event.payload.tripType),
+      }),
+    ]),
   ];
 }

--- a/src/features/slack/templates/booking-requested.ts
+++ b/src/features/slack/templates/booking-requested.ts
@@ -3,6 +3,7 @@ import type { LanguageKey } from '@/lib/i18n/constants';
 import type { BookingRequestedEvent } from '@/server/notifications/types';
 
 import {
+  contextBlock,
   formatDate,
   localizeTripType,
   type SlackBlock,
@@ -18,9 +19,13 @@ export function bookingRequested(
     textBlock(
       t(locale, 'booking.requested', {
         passengerName: event.payload.passengerName,
-        tripType: localizeTripType(locale, event.payload.tripType),
-        date: formatDate(event.payload.commuteDate, locale),
       })
     ),
+    contextBlock([
+      t(locale, 'booking.requestedContext', {
+        date: formatDate(event.payload.commuteDate, locale),
+        tripType: localizeTripType(locale, event.payload.tripType),
+      }),
+    ]),
   ];
 }

--- a/src/features/slack/templates/commute-canceled.ts
+++ b/src/features/slack/templates/commute-canceled.ts
@@ -3,6 +3,7 @@ import type { LanguageKey } from '@/lib/i18n/constants';
 import type { CommuteCanceledEvent } from '@/server/notifications/types';
 
 import {
+  contextBlock,
   formatDate,
   localizeCommuteType,
   type SlackBlock,
@@ -19,8 +20,12 @@ export function commuteCanceled(
       t(locale, 'commute.canceled', {
         driverName: event.payload.driverName,
         commuteType: localizeCommuteType(locale, event.payload.commuteType),
-        date: formatDate(event.payload.commuteDate, locale),
       })
     ),
+    contextBlock([
+      t(locale, 'commute.canceledContext', {
+        date: formatDate(event.payload.commuteDate, locale),
+      }),
+    ]),
   ];
 }

--- a/src/features/slack/templates/commute-created.ts
+++ b/src/features/slack/templates/commute-created.ts
@@ -2,7 +2,13 @@ import type { LanguageKey } from '@/lib/i18n/constants';
 
 import type { CommuteCreatedEvent } from '@/server/notifications/types';
 
-import { formatDate, localizeCommuteType, type SlackBlock, t } from './utils';
+import {
+  contextBlock,
+  formatDate,
+  localizeCommuteType,
+  type SlackBlock,
+  t,
+} from './utils';
 
 export function commuteCreated(
   event: CommuteCreatedEvent,
@@ -18,7 +24,6 @@ export function commuteCreated(
     driver,
     commuteType: localizeCommuteType(locale, event.payload.commuteType),
     date: formatDate(event.payload.commuteDate, locale),
-    seats: String(event.payload.seats),
   });
 
   const headerBlock: SlackBlock = {
@@ -44,5 +49,9 @@ export function commuteCreated(
     };
   });
 
-  return [headerBlock, { type: 'divider' }, ...stopBlocks];
+  const seatsContext = contextBlock([
+    t(locale, 'commute.createdContext', { seats: String(event.payload.seats) }),
+  ]);
+
+  return [headerBlock, { type: 'divider' }, ...stopBlocks, seatsContext];
 }

--- a/src/features/slack/templates/commute-updated.ts
+++ b/src/features/slack/templates/commute-updated.ts
@@ -3,6 +3,7 @@ import type { LanguageKey } from '@/lib/i18n/constants';
 import type { CommuteUpdatedEvent } from '@/server/notifications/types';
 
 import {
+  contextBlock,
   formatDate,
   localizeCommuteType,
   type SlackBlock,
@@ -19,8 +20,12 @@ export function commuteUpdated(
       t(locale, 'commute.updated', {
         driverName: event.payload.driverName,
         commuteType: localizeCommuteType(locale, event.payload.commuteType),
-        date: formatDate(event.payload.commuteDate, locale),
       })
     ),
+    contextBlock([
+      t(locale, 'commute.updatedContext', {
+        date: formatDate(event.payload.commuteDate, locale),
+      }),
+    ]),
   ];
 }

--- a/src/features/slack/templates/index.ts
+++ b/src/features/slack/templates/index.ts
@@ -14,6 +14,7 @@ import { commuteUpdated } from './commute-updated';
 import type { SlackBlock } from './utils';
 
 export type { SlackBlock };
+export { getFallbackText } from './utils';
 
 export function getSlackBlocks(
   event: NotificationEvent,

--- a/src/features/slack/templates/utils.ts
+++ b/src/features/slack/templates/utils.ts
@@ -71,3 +71,32 @@ export function textBlock(text: string): SlackBlock {
     text: { type: 'mrkdwn', text },
   };
 }
+
+export function contextBlock(elements: string[]): SlackBlock {
+  return {
+    type: 'context',
+    elements: elements.map((text) => ({ type: 'mrkdwn', text })),
+  };
+}
+
+export function getFallbackText(blocks: SlackBlock[]): string {
+  for (const block of blocks) {
+    if (
+      block.type === 'section' &&
+      typeof block.text === 'object' &&
+      block.text !== null
+    ) {
+      const text = (block.text as { text?: string }).text;
+      if (typeof text === 'string') {
+        return text
+          .replace(/[*_~`]/g, '')
+          .replace(/<@[^>]+>/g, '@user')
+          .replace(/<!here>/g, '@here')
+          .replace(/<!channel>/g, '@channel')
+          .replace(/\n/g, ' ')
+          .trim();
+      }
+    }
+  }
+  return 'New notification';
+}

--- a/src/locales/en/notifications.json
+++ b/src/locales/en/notifications.json
@@ -1,14 +1,21 @@
 {
   "booking": {
-    "requested": "🙋 *New booking request!*\n*{{passengerName}}* wants to join your commute on *{{date}}* — *{{tripType}}*.",
-    "accepted": "✅ *Booking confirmed!*\n*{{driverName}}* accepted your *{{tripType}}* booking for *{{date}}*.",
-    "refused": "❌ *Booking declined*\n*{{driverName}}* declined your *{{tripType}}* booking for *{{date}}*.",
-    "canceled": "🙅 *Booking canceled*\n*{{passengerName}}* canceled their *{{tripType}}* booking on *{{date}}*."
+    "requested": "🙋 *New booking request!*\n*{{passengerName}}* wants to join your commute.",
+    "requestedContext": "📅 {{date}} · {{tripType}}",
+    "accepted": "✅ *Booking confirmed!*\n*{{driverName}}* accepted your booking.",
+    "acceptedContext": "📅 {{date}} · {{tripType}}",
+    "refused": "❌ *Booking declined*\n*{{driverName}}* declined your booking.",
+    "refusedContext": "📅 {{date}} · {{tripType}}",
+    "canceled": "🙅 *Booking canceled*\n*{{passengerName}}* canceled their booking.",
+    "canceledContext": "📅 {{date}} · {{tripType}}"
   },
   "commute": {
-    "created": "🚗 *New commute posted!*\n{{driver}} — *{{commuteType}}* on *{{date}}*. 💺 *{{seats}}* seats available.",
-    "updated": "📝 *Commute updated*\n*{{driverName}}* updated the *{{commuteType}}* commute on *{{date}}*.",
-    "canceled": "❌ *Commute canceled*\n*{{driverName}}* canceled the *{{commuteType}}* commute on *{{date}}*.",
+    "created": "🚗 *New commute posted!*\n{{driver}} — *{{commuteType}}* on *{{date}}*.",
+    "createdContext": "💺 {{seats}} seats available",
+    "updated": "📝 *Commute updated*\n*{{driverName}}* updated the *{{commuteType}}* commute.",
+    "updatedContext": "📅 {{date}}",
+    "canceled": "❌ *Commute canceled*\n*{{driverName}}* canceled the *{{commuteType}}* commute.",
+    "canceledContext": "📅 {{date}}",
     "requested": "🙋 *Ride request!*\n{{requester}} is looking for a commute on *{{date}}*.",
     "requestedWithLocation": "🙋 *Ride request!*\n{{requester}} is looking for a commute to *{{locationName}}* on *{{date}}*.",
     "offerRide": "Offer a ride →"

--- a/src/locales/fr/notifications.json
+++ b/src/locales/fr/notifications.json
@@ -1,14 +1,21 @@
 {
   "booking": {
-    "requested": "🙋 *Nouvelle demande de réservation !*\n*{{passengerName}}* souhaite rejoindre votre trajet du *{{date}}* — *{{tripType}}*.",
-    "accepted": "✅ *Réservation confirmée !*\n*{{driverName}}* a accepté votre réservation *{{tripType}}* pour le *{{date}}*.",
-    "refused": "❌ *Réservation refusée*\n*{{driverName}}* a refusé votre réservation *{{tripType}}* pour le *{{date}}*.",
-    "canceled": "🙅 *Réservation annulée*\n*{{passengerName}}* a annulé sa réservation *{{tripType}}* du *{{date}}*."
+    "requested": "🙋 *Nouvelle demande de réservation !*\n*{{passengerName}}* souhaite rejoindre votre trajet.",
+    "requestedContext": "📅 {{date}} · {{tripType}}",
+    "accepted": "✅ *Réservation confirmée !*\n*{{driverName}}* a accepté votre réservation.",
+    "acceptedContext": "📅 {{date}} · {{tripType}}",
+    "refused": "❌ *Réservation refusée*\n*{{driverName}}* a refusé votre réservation.",
+    "refusedContext": "📅 {{date}} · {{tripType}}",
+    "canceled": "🙅 *Réservation annulée*\n*{{passengerName}}* a annulé sa réservation.",
+    "canceledContext": "📅 {{date}} · {{tripType}}"
   },
   "commute": {
-    "created": "🚗 *Nouveau trajet disponible !*\n{{driver}} — *{{commuteType}}* le *{{date}}*. 💺 *{{seats}}* places disponibles.",
-    "updated": "📝 *Trajet mis à jour*\n*{{driverName}}* a modifié le trajet *{{commuteType}}* du *{{date}}*.",
-    "canceled": "❌ *Trajet annulé*\n*{{driverName}}* a annulé le trajet *{{commuteType}}* du *{{date}}*.",
+    "created": "🚗 *Nouveau trajet disponible !*\n{{driver}} — *{{commuteType}}* le *{{date}}*.",
+    "createdContext": "💺 {{seats}} places disponibles",
+    "updated": "📝 *Trajet mis à jour*\n*{{driverName}}* a modifié le trajet *{{commuteType}}*.",
+    "updatedContext": "📅 {{date}}",
+    "canceled": "❌ *Trajet annulé*\n*{{driverName}}* a annulé le trajet *{{commuteType}}*.",
+    "canceledContext": "📅 {{date}}",
     "requested": "🙋 *Recherche de trajet !*\n{{requester}} cherche un trajet le *{{date}}*.",
     "requestedWithLocation": "🙋 *Recherche de trajet !*\n{{requester}} cherche un trajet vers *{{locationName}}* le *{{date}}*.",
     "offerRide": "Proposer un trajet →"

--- a/src/server/notifications/channels/slack.ts
+++ b/src/server/notifications/channels/slack.ts
@@ -6,7 +6,7 @@ import { DEFAULT_LANGUAGE_KEY } from '@/lib/i18n/constants';
 import { envClient } from '@/env/client';
 import { envServer } from '@/env/server';
 import { getSlackApp } from '@/features/slack/client';
-import { getSlackBlocks } from '@/features/slack/templates';
+import { getFallbackText, getSlackBlocks } from '@/features/slack/templates';
 
 import type { NotificationChannel } from '../types';
 
@@ -64,7 +64,7 @@ export function createSlackChannel(
           app.client.chat.postMessage({
             channel: defaultChannel,
             blocks,
-            text: `${event.payload.driverName} posted a new commute`,
+            text: getFallbackText(blocks),
           })
         );
         if (postResult.isErr()) {
@@ -112,7 +112,7 @@ export function createSlackChannel(
           app.client.chat.postMessage({
             channel: defaultChannel,
             blocks,
-            text: `${event.payload.requesterName} is looking for a commute`,
+            text: getFallbackText(blocks),
           })
         );
         if (postResult.isErr()) {
@@ -161,8 +161,7 @@ export function createSlackChannel(
         app.client.chat.postMessage({
           channel,
           blocks,
-          // Fallback text for notifications and accessibility
-          text: `You have a new ${event.type.replace('.', ' ')} notification`,
+          text: getFallbackText(blocks),
         })
       );
       if (postResult.isErr()) {


### PR DESCRIPTION
## Summary

- Adds context blocks to all DM notification templates (booking & commute events), separating the main message from metadata (date, trip/commute type) for a cleaner visual hierarchy
- Moves seat count from the `commute.created` broadcast header into a trailing context block
- Adds `getFallbackText()` helper in template utils that derives meaningful notification preview/accessibility text by stripping Slack markdown from block content — replacing the previous generic `"You have a new booking requested notification"` fallback
- Updates EN/FR i18n strings: main message copy now focuses on the action, metadata is shown in the context block below

## Test plan

- [x] Trigger a `booking.requested` event and verify the Slack DM shows a two-part message: headline + context line with date and trip type
- [x] Trigger a `commute.created` event and verify the broadcast channel message shows stops with a trailing "💺 N seats available" context block
- [x] Check that push notifications/screen readers receive meaningful fallback text (not the generic placeholder)
- [x] Verify French locale messages render correctly when `SLACK_LOCALE=fr`

Closes #84