### PR TITLE
fix: Swagger UI document could not be loaded (#102)

### DIFF
--- a/src/routes/api/openapi/app.schema.ts
+++ b/src/routes/api/openapi/app.schema.ts
@@ -1,7 +1,6 @@
 import { OpenAPIGenerator } from '@orpc/openapi';
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
 import { createFileRoute } from '@tanstack/react-router';
-import { json } from '@tanstack/react-start';
 
 import { envClient } from '@/env/client';
 import { router } from '@/server/router';
@@ -48,7 +47,7 @@ export const Route = createFileRoute('/api/openapi/app/schema')({
           },
         });
 
-        return json(spec);
+        return Response.json(spec);
       },
     },
   },

--- a/src/routes/api/openapi/auth.schema.ts
+++ b/src/routes/api/openapi/auth.schema.ts
@@ -1,5 +1,4 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { json } from '@tanstack/react-start';
 
 import { envClient } from '@/env/client';
 import { auth } from '@/server/auth';
@@ -16,7 +15,7 @@ export const Route = createFileRoute('/api/openapi/auth/schema')({
             url: `${envClient.VITE_BASE_URL}/api/auth`,
           },
         ];
-        return json(spec);
+        return Response.json(spec);
       },
     },
   },

--- a/src/server/routers/account.ts
+++ b/src/server/routers/account.ts
@@ -61,7 +61,7 @@ export default {
 
   getAutoAccept: orgProcedure()
     .route({ method: 'GET', path: '/account/auto-accept', tags })
-    .input(z.void())
+    .input(z.object({}).prefault({}))
     .output(z.object({ autoAccept: z.boolean() }))
     .handler(async ({ context }) => {
       return context.account.getMemberAutoAccept(context.memberId);
@@ -80,7 +80,7 @@ export default {
 
   getNotificationPreferences: orgProcedure()
     .route({ method: 'GET', path: '/account/notification-preferences', tags })
-    .input(z.void())
+    .input(z.object({}).prefault({}))
     .output(
       z.array(
         z.object({ channel: zNotificationChannel(), enabled: z.boolean() })

--- a/src/server/routers/booking.ts
+++ b/src/server/routers/booking.ts
@@ -251,7 +251,7 @@ export default {
 
   pendingRequestCount: procedure({ permissions: { booking: ['read'] } })
     .route({ method: 'GET', path: '/bookings/pending-count', tags })
-    .input(z.void())
+    .input(z.object({}).prefault({}))
     .output(z.object({ count: z.number() }))
     .handler(async ({ context }) => {
       const count = await context.bookings.countPendingForDriver(


### PR DESCRIPTION
## Summary

Fixes #102 — The Scalar API reference UI was showing "Document 'api-1' could not be loaded" due to two issues:

- **`json()` not exported**: `json()` was imported from `@tanstack/react-start` which doesn't export this helper in v1.157.x. Calling it at runtime threw a `TypeError`, causing the schema endpoints (`/api/openapi/app/schema`, `/api/openapi/auth/schema`) to return 500 errors. Fixed by replacing with the native `Response.json()`.
- **`z.void()` on GET procedures**: Three GET procedures used `.input(z.void())`, which ORPC's `OpenAPIGenerator` rejects (GET inputs must satisfy `object | any | unknown`). Fixed by replacing with `z.object({}).prefault({})`, which satisfies the constraint while keeping the input optional for callers.

## Test plan

- [x] Navigate to `/api/openapi/app` — Scalar UI loads and displays the Application API spec
- [x] Navigate to `/api/openapi/auth` — Scalar UI loads and displays the Auth API spec
- [x] Verify `/api/openapi/app/schema` returns valid JSON
- [x] Verify `/api/openapi/auth/schema` returns valid JSON