### PR TITLE
feat: implement edit commute

### DIFF
--- a/src/features/commute/app/page-commute-update.tsx
+++ b/src/features/commute/app/page-commute-update.tsx
@@ -1,0 +1,204 @@
+import { getUiState } from '@bearstudio/ui-state';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useCanGoBack, useRouter } from '@tanstack/react-router';
+import { AlertCircleIcon } from 'lucide-react';
+import { FieldPath, FormStateSubscribe, useForm, Watch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import { orpc } from '@/lib/orpc/client';
+
+import { BackButton } from '@/components/back-button';
+import {
+  Form,
+  MultiStepForm,
+  MultiStepFormContent,
+  MultiStepFormNavigation,
+  MultiStepFormStep,
+} from '@/components/form';
+import { PreventNavigation } from '@/components/prevent-navigation';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { StepDetailsCommuteUpdate } from '@/features/commute/form-commute/step-details-commute-update';
+import { StepInwardStops } from '@/features/commute/form-commute/step-inward-stops';
+import { StepOutwardStops } from '@/features/commute/form-commute/step-outward-stops';
+import { StepRecap } from '@/features/commute/form-commute/step-recap';
+import {
+  asCommuteBase,
+  FormFieldsCommuteUpdate,
+  zFormFieldsCommuteUpdate,
+} from '@/features/commute/schema';
+import { useShouldShowNav } from '@/layout/app/layout';
+import {
+  PageLayout,
+  PageLayoutContent,
+  PageLayoutTopBar,
+  PageLayoutTopBarTitle,
+} from '@/layout/app/page-layout';
+
+export const PageCommuteUpdate = (props: { id: string; orgSlug: string }) => {
+  const { t } = useTranslation(['commute']);
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
+  useShouldShowNav('desktop-only');
+
+  const commuteQuery = useQuery(
+    orpc.commute.getById.queryOptions({
+      input: { id: props.id },
+    })
+  );
+
+  const commuteUpdate = useMutation(
+    orpc.commute.update.mutationOptions({
+      onSuccess: async (_data, _variables, _onMutateResult, context) => {
+        await Promise.all([
+          context.client.invalidateQueries({
+            queryKey: orpc.commute.getById.key({
+              input: { id: props.id },
+            }),
+          }),
+          context.client.invalidateQueries({
+            queryKey: orpc.commute.getMyCommutes.key(),
+            type: 'all',
+          }),
+        ]);
+
+        if (canGoBack) {
+          router.history.back({ ignoreBlocker: true });
+        } else {
+          router.navigate({
+            to: '/app/$orgSlug/commutes',
+            params: { orgSlug: props.orgSlug },
+            replace: true,
+            ignoreBlocker: true,
+          });
+        }
+      },
+    })
+  );
+
+  const form = useForm<FormFieldsCommuteUpdate>({
+    resolver: zodResolver(zFormFieldsCommuteUpdate()),
+    defaultValues: {
+      type: 'ROUND',
+      seats: 1,
+      comment: null,
+      stops: [],
+    },
+    values: commuteQuery.data
+      ? {
+          seats: commuteQuery.data.seats,
+          type: commuteQuery.data.type,
+          comment: commuteQuery.data.comment ?? null,
+          stops: commuteQuery.data.stops.map((stop) => ({
+            locationId: stop.locationId,
+            outwardTime: stop.outwardTime,
+            inwardTime: stop.inwardTime ?? null,
+          })),
+        }
+      : undefined,
+  });
+
+  const ui = getUiState((set) => {
+    if (commuteQuery.status === 'pending') return set('pending');
+    if (commuteQuery.status === 'error') return set('error');
+    return set('default', { commute: commuteQuery.data });
+  });
+
+  const handleSubmit = form.handleSubmit((values) => {
+    commuteUpdate.mutate({
+      id: props.id,
+      ...values,
+      stops: values.stops.map((stop, index) => ({ ...stop, order: index })),
+    });
+  });
+
+  return (
+    <>
+      <FormStateSubscribe
+        control={form.control}
+        render={({ isDirty }) => <PreventNavigation shouldBlock={isDirty} />}
+      />
+      <Form {...form} noHtmlForm>
+        <MultiStepForm freeNavigation>
+          <PageLayout>
+            <PageLayoutTopBar startActions={<BackButton />}>
+              <PageLayoutTopBarTitle>
+                {ui
+                  .match('pending', () => <Skeleton className="h-4 w-48" />)
+                  .match('error', () => (
+                    <AlertCircleIcon className="size-4 text-muted-foreground" />
+                  ))
+                  .match('default', () => <>{t('commute:update.title')}</>)
+                  .exhaustive()}
+              </PageLayoutTopBarTitle>
+            </PageLayoutTopBar>
+            <PageLayoutContent>
+              <MultiStepFormContent />
+              <MultiStepFormStep
+                name={t('commute:stepper.details')}
+                onNext={() => form.trigger(['seats', 'type'])}
+              >
+                <StepDetailsCommuteUpdate />
+              </MultiStepFormStep>
+              <MultiStepFormStep
+                name={t('commute:stepper.stops')}
+                onNext={() => {
+                  const stops = form.getValues('stops');
+                  return form.trigger(
+                    stops.flatMap((_, i) => [
+                      `stops.${i}.locationId` as FieldPath<FormFieldsCommuteUpdate>,
+                      `stops.${i}.outwardTime` as FieldPath<FormFieldsCommuteUpdate>,
+                    ])
+                  );
+                }}
+              >
+                <StepOutwardStops
+                  {...asCommuteBase(form)}
+                  ns="commute"
+                  defaultStop={{
+                    locationId: '',
+                    outwardTime: '',
+                    inwardTime: null,
+                  }}
+                />
+              </MultiStepFormStep>
+              <Watch
+                control={form.control}
+                name="type"
+                render={(type) =>
+                  type === 'ROUND' ? (
+                    <MultiStepFormStep
+                      name={t('commute:stepper.inwardStops')}
+                      onNext={() => {
+                        const stops = form.getValues('stops');
+                        return form.trigger(
+                          stops.map(
+                            (_, i) =>
+                              `stops.${i}.inwardTime` as FieldPath<FormFieldsCommuteUpdate>
+                          )
+                        );
+                      }}
+                    >
+                      <StepInwardStops {...asCommuteBase(form)} ns="commute" />
+                    </MultiStepFormStep>
+                  ) : null
+                }
+              />
+              <MultiStepFormStep name={t('commute:stepper.recap')}>
+                <StepRecap {...asCommuteBase(form)} ns="commute" />
+              </MultiStepFormStep>
+            </PageLayoutContent>
+            <MultiStepFormNavigation
+              onSubmit={handleSubmit}
+              isSubmitting={commuteUpdate.isPending}
+              submitLabel={t('commute:update.submitButton')}
+              nextLabel={t('commute:stepper.next')}
+              backLabel={t('commute:stepper.back')}
+            />
+          </PageLayout>
+        </MultiStepForm>
+      </Form>
+    </>
+  );
+};

--- a/src/features/commute/app/page-commutes.tsx
+++ b/src/features/commute/app/page-commutes.tsx
@@ -56,7 +56,6 @@ export const PageCommutes = () => {
   ]);
   const isMobile = useIsMobile();
   const session = authClient.useSession();
-
   const commutesQuery = useInfiniteQuery(
     orpc.commute.getMyCommutes.infiniteOptions({
       input: (cursor: string | undefined) => ({
@@ -222,6 +221,7 @@ export const PageCommutes = () => {
                         <CardCommuteStopsList stops={item.stops} />
                         <CardCommuteActions
                           isDriver={isDriver}
+                          commuteId={item.id}
                           driverPhone={item.driver.phone}
                           cancelConfirmDescription={
                             <CommuteCancelDescription

--- a/src/features/commute/card-commute-actions.tsx
+++ b/src/features/commute/card-commute-actions.tsx
@@ -6,8 +6,11 @@ import { Button } from '@/components/ui/button';
 import { ConfirmResponsiveDrawer } from '@/components/ui/confirm-responsive-drawer';
 import { ResponsiveIconButton } from '@/components/ui/responsive-icon-button';
 
+import { OrgButtonLink } from '@/features/organization/org-button-link';
+
 type CardCommuteActionsProps = {
   isDriver: boolean;
+  commuteId: string;
   driverPhone?: string | null;
   cancelConfirmDescription: ReactNode;
   onCancel: () => void | Promise<void>;
@@ -15,6 +18,7 @@ type CardCommuteActionsProps = {
 
 export function CardCommuteActions({
   isDriver,
+  commuteId,
   driverPhone,
   cancelConfirmDescription,
   onCancel,
@@ -25,10 +29,15 @@ export function CardCommuteActions({
     <div className="ms-auto flex items-center gap-2">
       {isDriver && (
         <>
-          <Button size="sm" variant="secondary">
+          <OrgButtonLink
+            size="sm"
+            variant="secondary"
+            to="/app/$orgSlug/commutes/$id/update"
+            params={{ id: commuteId }}
+          >
             <PencilIcon />
             {t('commute:list.editAction')}
-          </Button>
+          </OrgButtonLink>
           <ConfirmResponsiveDrawer
             description={cancelConfirmDescription}
             confirmText={t('common:actions.delete')}

--- a/src/features/commute/form-commute/step-details-commute-update.tsx
+++ b/src/features/commute/form-commute/step-details-commute-update.tsx
@@ -1,0 +1,57 @@
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import {
+  FormField,
+  FormFieldController,
+  FormFieldLabel,
+} from '@/components/form';
+import { Checkbox } from '@/components/ui/checkbox';
+
+import type { FormFieldsCommuteUpdate } from '@/features/commute/schema';
+
+export const StepDetailsCommuteUpdate = () => {
+  const { t } = useTranslation(['commute']);
+  const form = useFormContext<FormFieldsCommuteUpdate>();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <FormFieldController
+        type="custom"
+        control={form.control}
+        name="type"
+        render={({ field }) => (
+          <Checkbox
+            checked={field.value === 'ROUND'}
+            onCheckedChange={(checked) =>
+              field.onChange(checked ? 'ROUND' : 'ONEWAY')
+            }
+          >
+            {t('commute:form.roundTrip')}
+          </Checkbox>
+        )}
+      />
+
+      <FormField>
+        <FormFieldLabel required>{t('commute:form.seats')}</FormFieldLabel>
+        <FormFieldController
+          type="number"
+          control={form.control}
+          name="seats"
+          min={1}
+          buttons="mobile"
+        />
+      </FormField>
+
+      <FormField>
+        <FormFieldLabel>{t('commute:form.comment')}</FormFieldLabel>
+        <FormFieldController
+          type="textarea"
+          control={form.control}
+          name="comment"
+          placeholder={t('commute:form.commentPlaceholder')}
+        />
+      </FormField>
+    </div>
+  );
+};

--- a/src/features/commute/schema.ts
+++ b/src/features/commute/schema.ts
@@ -4,7 +4,10 @@ import { z } from 'zod';
 
 import { zu } from '@/lib/zod/zod-utils';
 
-import { createCommuteRules } from '@/features/commute/form-commute-rules';
+import {
+  createCommuteRules,
+  createStopOrderRules,
+} from '@/features/commute/form-commute-rules';
 import { zLocation } from '@/features/location/schema';
 import { zUser } from '@/features/user/schema';
 
@@ -94,21 +97,23 @@ export function asCommuteBase<
   };
 }
 
+const zFormFieldsCommuteShared = () =>
+  z.object({
+    seats: z
+      .number({ error: t('common:errors.required') })
+      .int()
+      .min(1, t('commute:form.errors.seatsMin')),
+    type: zCommuteType(),
+    comment: zu.fieldText.nullish(),
+    stops: z
+      .array(zFormFieldsStopInput())
+      .min(2, t('commute:form.errors.stopsMin')),
+  });
+
 export type FormFieldsCommute = z.infer<ReturnType<typeof zFormFieldsCommute>>;
 export const zFormFieldsCommute = () =>
-  z
-    .object({
-      date: z.date({ error: t('common:errors.required') }),
-      seats: z
-        .number({ error: t('common:errors.required') })
-        .int()
-        .min(1, t('commute:form.errors.seatsMin')),
-      type: zCommuteType(),
-      comment: zu.fieldText.nullish(),
-      stops: z
-        .array(zFormFieldsStopInput())
-        .min(2, t('commute:form.errors.stopsMin')),
-    })
+  zFormFieldsCommuteShared()
+    .extend({ date: z.date({ error: t('common:errors.required') }) })
     .superRefine((data, ctx) => {
       const rules = createCommuteRules(data);
 
@@ -154,6 +159,40 @@ export const zFormFieldsCommute = () =>
         }
       });
     });
+
+export type FormFieldsCommuteUpdate = z.infer<
+  ReturnType<typeof zFormFieldsCommuteUpdate>
+>;
+export const zFormFieldsCommuteUpdate = () =>
+  zFormFieldsCommuteShared().superRefine((data, ctx) => {
+    const rules = createStopOrderRules(data);
+
+    data.stops.forEach((stop, index) => {
+      if (!rules.shouldInwardBeAfterOutward(stop)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: t('commute:form.errors.inwardBeforeOutward'),
+          path: ['stops', index, 'inwardTime'],
+        });
+      }
+
+      if (!rules.shouldOutwardBeIncreasing(stop, index)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: t('commute:form.errors.outwardNotIncreasing'),
+          path: ['stops', index, 'outwardTime'],
+        });
+      }
+
+      if (!rules.shouldInwardBeDecreasing(stop, index)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: t('commute:form.errors.inwardNotDecreasing'),
+          path: ['stops', index, 'inwardTime'],
+        });
+      }
+    });
+  });
 
 export type UserSummary = z.infer<ReturnType<typeof zUserSummary>>;
 export const zUserSummary = () =>

--- a/src/features/dashboard/dashboard-commute-card.tsx
+++ b/src/features/dashboard/dashboard-commute-card.tsx
@@ -135,6 +135,7 @@ export const DashboardCommuteCard = ({
           />
           <CardCommuteActions
             isDriver={isDriver}
+            commuteId={commute.id}
             driverPhone={commute.driver.phone}
             cancelConfirmDescription={
               <CommuteCancelDescription

--- a/src/locales/en/commute.json
+++ b/src/locales/en/commute.json
@@ -40,6 +40,10 @@
       "success": "Request sent!"
     }
   },
+  "update": {
+    "title": "Edit Commute",
+    "submitButton": "Save"
+  },
   "templatePicker": {
     "title": "My templates",
     "emptyState": "Save time: create a template",

--- a/src/locales/fr/commute.json
+++ b/src/locales/fr/commute.json
@@ -40,6 +40,10 @@
       "success": "Demande envoyée !"
     }
   },
+  "update": {
+    "title": "Modifier le trajet",
+    "submitButton": "Enregistrer"
+  },
   "templatePicker": {
     "title": "Mes modèles",
     "emptyState": "Gagnez du temps : créez un modèle",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -54,6 +54,7 @@ import { Route as AppOrgSlugCommutesNewIndexRouteImport } from './routes/app/$or
 import { Route as AppOrgSlugAccountLocationsIndexRouteImport } from './routes/app/$orgSlug/account/locations/index'
 import { Route as AppOrgSlugAccountCommuteTemplatesIndexRouteImport } from './routes/app/$orgSlug/account/commute-templates/index'
 import { Route as ManagerOrgSlugUsersIdUpdateIndexRouteImport } from './routes/manager/$orgSlug/users/$id.update.index'
+import { Route as AppOrgSlugCommutesIdUpdateIndexRouteImport } from './routes/app/$orgSlug/commutes/$id.update.index'
 import { Route as AppOrgSlugAccountCommuteTemplatesNewIndexRouteImport } from './routes/app/$orgSlug/account/commute-templates/new.index'
 import { Route as AppOrgSlugAccountCommuteTemplatesIdUpdateIndexRouteImport } from './routes/app/$orgSlug/account/commute-templates/$id.update.index'
 
@@ -295,6 +296,12 @@ const ManagerOrgSlugUsersIdUpdateIndexRoute =
     path: '/users/$id/update/',
     getParentRoute: () => ManagerOrgSlugRouteRoute,
   } as any)
+const AppOrgSlugCommutesIdUpdateIndexRoute =
+  AppOrgSlugCommutesIdUpdateIndexRouteImport.update({
+    id: '/commutes/$id/update/',
+    path: '/commutes/$id/update/',
+    getParentRoute: () => AppOrgSlugRouteRoute,
+  } as any)
 const AppOrgSlugAccountCommuteTemplatesNewIndexRoute =
   AppOrgSlugAccountCommuteTemplatesNewIndexRouteImport.update({
     id: '/account/commute-templates/new/',
@@ -354,6 +361,7 @@ export interface FileRoutesByFullPath {
   '/manager/$orgSlug/users/new/': typeof ManagerOrgSlugUsersNewIndexRoute
   '/manager/users/$id/update/': typeof ManagerUsersIdUpdateIndexRoute
   '/app/$orgSlug/account/commute-templates/new/': typeof AppOrgSlugAccountCommuteTemplatesNewIndexRoute
+  '/app/$orgSlug/commutes/$id/update/': typeof AppOrgSlugCommutesIdUpdateIndexRoute
   '/manager/$orgSlug/users/$id/update/': typeof ManagerOrgSlugUsersIdUpdateIndexRoute
   '/app/$orgSlug/account/commute-templates/$id/update/': typeof AppOrgSlugAccountCommuteTemplatesIdUpdateIndexRoute
 }
@@ -396,6 +404,7 @@ export interface FileRoutesByTo {
   '/manager/$orgSlug/users/new': typeof ManagerOrgSlugUsersNewIndexRoute
   '/manager/users/$id/update': typeof ManagerUsersIdUpdateIndexRoute
   '/app/$orgSlug/account/commute-templates/new': typeof AppOrgSlugAccountCommuteTemplatesNewIndexRoute
+  '/app/$orgSlug/commutes/$id/update': typeof AppOrgSlugCommutesIdUpdateIndexRoute
   '/manager/$orgSlug/users/$id/update': typeof ManagerOrgSlugUsersIdUpdateIndexRoute
   '/app/$orgSlug/account/commute-templates/$id/update': typeof AppOrgSlugAccountCommuteTemplatesIdUpdateIndexRoute
 }
@@ -446,6 +455,7 @@ export interface FileRoutesById {
   '/manager/$orgSlug/users/new/': typeof ManagerOrgSlugUsersNewIndexRoute
   '/manager/users/$id/update/': typeof ManagerUsersIdUpdateIndexRoute
   '/app/$orgSlug/account/commute-templates/new/': typeof AppOrgSlugAccountCommuteTemplatesNewIndexRoute
+  '/app/$orgSlug/commutes/$id/update/': typeof AppOrgSlugCommutesIdUpdateIndexRoute
   '/manager/$orgSlug/users/$id/update/': typeof ManagerOrgSlugUsersIdUpdateIndexRoute
   '/app/$orgSlug/account/commute-templates/$id/update/': typeof AppOrgSlugAccountCommuteTemplatesIdUpdateIndexRoute
 }
@@ -497,6 +507,7 @@ export interface FileRouteTypes {
     | '/manager/$orgSlug/users/new/'
     | '/manager/users/$id/update/'
     | '/app/$orgSlug/account/commute-templates/new/'
+    | '/app/$orgSlug/commutes/$id/update/'
     | '/manager/$orgSlug/users/$id/update/'
     | '/app/$orgSlug/account/commute-templates/$id/update/'
   fileRoutesByTo: FileRoutesByTo
@@ -539,6 +550,7 @@ export interface FileRouteTypes {
     | '/manager/$orgSlug/users/new'
     | '/manager/users/$id/update'
     | '/app/$orgSlug/account/commute-templates/new'
+    | '/app/$orgSlug/commutes/$id/update'
     | '/manager/$orgSlug/users/$id/update'
     | '/app/$orgSlug/account/commute-templates/$id/update'
   id:
@@ -588,6 +600,7 @@ export interface FileRouteTypes {
     | '/manager/$orgSlug/users/new/'
     | '/manager/users/$id/update/'
     | '/app/$orgSlug/account/commute-templates/new/'
+    | '/app/$orgSlug/commutes/$id/update/'
     | '/manager/$orgSlug/users/$id/update/'
     | '/app/$orgSlug/account/commute-templates/$id/update/'
   fileRoutesById: FileRoutesById
@@ -926,6 +939,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ManagerOrgSlugUsersIdUpdateIndexRouteImport
       parentRoute: typeof ManagerOrgSlugRouteRoute
     }
+    '/app/$orgSlug/commutes/$id/update/': {
+      id: '/app/$orgSlug/commutes/$id/update/'
+      path: '/commutes/$id/update'
+      fullPath: '/app/$orgSlug/commutes/$id/update/'
+      preLoaderRoute: typeof AppOrgSlugCommutesIdUpdateIndexRouteImport
+      parentRoute: typeof AppOrgSlugRouteRoute
+    }
     '/app/$orgSlug/account/commute-templates/new/': {
       id: '/app/$orgSlug/account/commute-templates/new/'
       path: '/account/commute-templates/new'
@@ -952,6 +972,7 @@ interface AppOrgSlugRouteRouteChildren {
   AppOrgSlugAccountLocationsIndexRoute: typeof AppOrgSlugAccountLocationsIndexRoute
   AppOrgSlugCommutesNewIndexRoute: typeof AppOrgSlugCommutesNewIndexRoute
   AppOrgSlugAccountCommuteTemplatesNewIndexRoute: typeof AppOrgSlugAccountCommuteTemplatesNewIndexRoute
+  AppOrgSlugCommutesIdUpdateIndexRoute: typeof AppOrgSlugCommutesIdUpdateIndexRoute
   AppOrgSlugAccountCommuteTemplatesIdUpdateIndexRoute: typeof AppOrgSlugAccountCommuteTemplatesIdUpdateIndexRoute
 }
 
@@ -966,6 +987,7 @@ const AppOrgSlugRouteRouteChildren: AppOrgSlugRouteRouteChildren = {
   AppOrgSlugCommutesNewIndexRoute: AppOrgSlugCommutesNewIndexRoute,
   AppOrgSlugAccountCommuteTemplatesNewIndexRoute:
     AppOrgSlugAccountCommuteTemplatesNewIndexRoute,
+  AppOrgSlugCommutesIdUpdateIndexRoute: AppOrgSlugCommutesIdUpdateIndexRoute,
   AppOrgSlugAccountCommuteTemplatesIdUpdateIndexRoute:
     AppOrgSlugAccountCommuteTemplatesIdUpdateIndexRoute,
 }

--- a/src/routes/app/$orgSlug/commutes/$id.update.index.tsx
+++ b/src/routes/app/$orgSlug/commutes/$id.update.index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { PageCommuteUpdate } from '@/features/commute/app/page-commute-update';
+
+export const Route = createFileRoute('/app/$orgSlug/commutes/$id/update/')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { id, orgSlug } = Route.useParams();
+  return <PageCommuteUpdate id={id} orgSlug={orgSlug} />;
+}


### PR DESCRIPTION
## Summary

- Add multi-step edit page for commutes (`page-commute-update.tsx`) following the commute template update pattern
- Add `StepDetailsCommuteUpdate` step (seats, type, comment — no date, since date is immutable on edit)
- Extract shared form fields into `zFormFieldsCommuteShared` so `zFormFieldsCommuteUpdate` derives from the create schema without duplication
- Wire the Edit button in `CardCommuteActions` using `OrgButtonLink` directly (no `onEdit` callback needed)
- Register the new route `/app/$orgSlug/commutes/$id/update/` in the route tree
- Passenger notifications on edit are handled by the existing backend `update` endpoint

## Test plan

- [ ] As a driver, open the commutes list and click Edit on a commute
- [ ] Verify the multi-step form pre-populates with existing commute data (seats, type, comment, stops)
- [ ] Edit one or more fields and submit — verify the commute is updated
- [ ] Verify navigation returns to the commutes list after saving
- [ ] Verify that if a passenger has an accepted booking, a `commute.updated` terminal notification appears on save
- [ ] Verify the Cancel action still works alongside the Edit button