### PR TITLE
fix: replace raw Slack mrkdwn syntax with jsx-slack components

### DIFF
--- a/src/features/slack/templates/commute-created.tsx
+++ b/src/features/slack/templates/commute-created.tsx
@@ -37,14 +37,23 @@ function mapsUrl(address: string): string {
   return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`;
 }
 
-function stopLabel(stop: CommuteCreatedStop): string {
+function StopLabel({ stop }: { stop: CommuteCreatedStop }) {
   const times = stop.inwardTime
     ? `⬆ ${stop.outwardTime}   ⬇ ${stop.inwardTime}`
     : `⬆ ${stop.outwardTime}`;
-  const addressLine = stop.locationAddress
-    ? `\n<${mapsUrl(stop.locationAddress)}|${stop.locationAddress}>`
-    : '';
-  return `📍 *${stop.locationName}*   ${times}${addressLine}`;
+  return (
+    <>
+      {'📍 '}
+      <b>{stop.locationName}</b>
+      {`   ${times}`}
+      {stop.locationAddress && (
+        <>
+          <br />
+          <a href={mapsUrl(stop.locationAddress)}>{stop.locationAddress}</a>
+        </>
+      )}
+    </>
+  );
 }
 
 export function CommuteCreated({
@@ -54,12 +63,6 @@ export function CommuteCreated({
   driverAvatarUrl,
 }: Props) {
   const { payload } = event;
-  const driver = driverSlackId ? `<@${driverSlackId}>` : payload.driverName;
-
-  const headerText = [
-    `*${driver}* — *${localizeCommuteType(payload.commuteType)}*`,
-    formatDate(payload.commuteDate),
-  ].join('\n');
 
   const seatsKey =
     payload.seats === 1
@@ -69,7 +72,10 @@ export function CommuteCreated({
   return (
     <Blocks>
       <SlackHeader>
-        {`<!here> ${i18n.t('notifications:commute.createdAnnouncement')}`}
+        <>
+          <a href="@here" />{' '}
+          {i18n.t('notifications:commute.createdAnnouncement')}
+        </>
       </SlackHeader>
       <Divider />
       <SlackBody
@@ -79,12 +85,26 @@ export function CommuteCreated({
           ) : null
         }
       >
-        {headerText}
+        <>
+          <b>
+            {driverSlackId ? (
+              <a href={`@${driverSlackId}`} />
+            ) : (
+              payload.driverName
+            )}
+          </b>
+          {` — `}
+          <b>{localizeCommuteType(payload.commuteType)}</b>
+          <br />
+          {formatDate(payload.commuteDate)}
+        </>
       </SlackBody>
       {payload.stops.map((stop) => (
         // eslint-disable-next-line @eslint-react/no-missing-key
         <Section>
-          <Mrkdwn>{stopLabel(stop)}</Mrkdwn>
+          <Mrkdwn>
+            <StopLabel stop={stop} />
+          </Mrkdwn>
           <Button
             url={stopBookingUrl(
               baseUrl,

--- a/src/features/slack/templates/commute-requested.tsx
+++ b/src/features/slack/templates/commute-requested.tsx
@@ -17,10 +17,6 @@ type Props = {
 };
 
 export function CommuteRequested({ event, baseUrl, requesterSlackId }: Props) {
-  const requester = requesterSlackId
-    ? `<@${requesterSlackId}>`
-    : event.payload.requesterName;
-
   const dateParam =
     event.payload.commuteDate instanceof Date
       ? event.payload.commuteDate.toISOString()
@@ -31,17 +27,12 @@ export function CommuteRequested({ event, baseUrl, requesterSlackId }: Props) {
   const { locationName } = event.payload;
   const formattedDate = formatDate(event.payload.commuteDate);
 
-  const headline = `<!here> ${i18n.t('notifications:commute.requested.headline')}`;
-  const body = locationName
+  const bodySuffix = locationName
     ? i18n.t('notifications:commute.requestedWithLocation.body', {
-        requester,
         date: formattedDate,
         locationName,
       })
-    : i18n.t('notifications:commute.requested.body', {
-        requester,
-        date: formattedDate,
-      });
+    : i18n.t('notifications:commute.requested.body', { date: formattedDate });
 
   const contextText = locationName
     ? i18n.t('notifications:commute.requestedContextWithLocation', {
@@ -59,9 +50,21 @@ export function CommuteRequested({ event, baseUrl, requesterSlackId }: Props) {
           </Button>
         }
       >
-        {headline}
+        <>
+          <a href="@here" />{' '}
+          {i18n.t('notifications:commute.requested.headline')}
+        </>
       </SlackHeader>
-      <SlackBody>{body}</SlackBody>
+      <SlackBody>
+        <>
+          {requesterSlackId ? (
+            <a href={`@${requesterSlackId}`} />
+          ) : (
+            event.payload.requesterName
+          )}{' '}
+          {bodySuffix}
+        </>
+      </SlackBody>
       <SlackFooter>{contextText}</SlackFooter>
     </Blocks>
   );

--- a/src/features/slack/templates/commute-updated.tsx
+++ b/src/features/slack/templates/commute-updated.tsx
@@ -62,7 +62,23 @@ export function CommuteUpdated({ event, baseUrl }: Props) {
         <>
           <Divider />
           <Section>
-            <Mrkdwn>{diffLines.join('\n')}</Mrkdwn>
+            <Mrkdwn>
+              <>
+                {diffLines[0]}
+                {diffLines[1] !== undefined && (
+                  <>
+                    <br />
+                    {diffLines[1]}
+                  </>
+                )}
+                {diffLines[2] !== undefined && (
+                  <>
+                    <br />
+                    {diffLines[2]}
+                  </>
+                )}
+              </>
+            </Mrkdwn>
           </Section>
         </>
       ) : null}

--- a/src/locales/en/notifications.json
+++ b/src/locales/en/notifications.json
@@ -44,10 +44,10 @@
     "canceledContext": "📅 {{date}}",
     "requested": {
       "headline": "🙋 *Ride request!*",
-      "body": "{{requester}} is looking for a commute on *{{date}}*."
+      "body": "is looking for a commute on *{{date}}*."
     },
     "requestedWithLocation": {
-      "body": "{{requester}} is looking for a commute to *{{locationName}}* on *{{date}}*."
+      "body": "is looking for a commute to *{{locationName}}* on *{{date}}*."
     },
     "requestedContext": "📅 {{date}}",
     "requestedContextWithLocation": "📅 {{date}}   ·   📍 {{locationName}}",

--- a/src/locales/fr/notifications.json
+++ b/src/locales/fr/notifications.json
@@ -44,10 +44,10 @@
     "canceledContext": "📅 {{date}}",
     "requested": {
       "headline": "🙋 *Recherche de trajet !*",
-      "body": "{{requester}} cherche un trajet le *{{date}}*."
+      "body": "cherche un trajet le *{{date}}*."
     },
     "requestedWithLocation": {
-      "body": "{{requester}} cherche un trajet vers *{{locationName}}* le *{{date}}*."
+      "body": "cherche un trajet vers *{{locationName}}* le *{{date}}*."
     },
     "requestedContext": "📅 {{date}}",
     "requestedContextWithLocation": "📅 {{date}}   ·   📍 {{locationName}}",


### PR DESCRIPTION
## Summary

- Replace `<!here>`, `<@userId>`, and `<url|text>` raw mrkdwn strings with jsx-slack JSX components (`<a href="@here" />`, `<a href="@userId" />`, `<a href={url}>text</a>`) — jsx-slack escapes `<` and `>` in string content, so these were silently broken
- Fix `\n` line breaks by using `<br />` instead of newline characters in string nodes, which jsx-slack collapses like HTML whitespace
- Simplify `commute.requested.body` i18n keys (EN + FR) to drop `{{requester}}` so the mention can be injected as a proper JSX element before the translated suffix

## Affected templates

- `commute-created`: `<!here>` header, driver `<@slackId>` mention, stop address `<url|text>` links, `\n` between commute type and date
- `commute-requested`: `<!here>` header, requester `<@slackId>` mention
- `commute-updated`: `\n` between diff lines