### PR TITLE
test: add dashboard e2e specs

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'e2e/utils';
+import { USER_FILE } from 'e2e/utils/constants';
+
+test.describe('Dashboard — Commute Discovery', () => {
+  test.use({ storageState: USER_FILE });
+
+  test('View the 7-day commute calendar', async ({ page, dashboard }) => {
+    await page.to('/app');
+
+    await expect(page.locator('[data-testid="layout-app"]')).toBeVisible();
+
+    const firstCard = dashboard.commuteCard();
+    await expect(firstCard).toBeVisible();
+
+    // At least one day section heading (date label) should be visible
+    await expect(
+      page.locator('[data-slot="card-commute"]').first()
+    ).toBeVisible();
+  });
+
+  test('Expand and collapse a commute card', async ({ page, dashboard }) => {
+    await page.to('/app');
+
+    const firstCard = dashboard.commuteCard();
+    await expect(firstCard).toBeVisible();
+
+    // Expand the card
+    await dashboard.expandCard(firstCard);
+    await expect(dashboard.cardContent(firstCard)).toBeVisible();
+
+    // Collapse the card
+    await firstCard.locator('[data-slot="card-commute-trigger"]').click();
+    await expect(dashboard.cardContent(firstCard)).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #121

## Summary

- Adds `e2e/dashboard.spec.ts` covering the two dashboard happy-path scenarios from `e2e/specs/happy-path.md`
- **2.1** View the 7-day commute calendar — asserts `[data-testid="layout-app"]` and at least one `[data-slot="card-commute"]` are visible after navigating to `/app`
- **2.2** Expand and collapse a commute card — uses the existing `DashboardPage` helpers to expand a card (asserts content visible) then collapse it (asserts content hidden)

## Test plan

- [ ] Run `pnpm playwright test dashboard.spec.ts` against a local dev server and confirm both tests pass