### PR TITLE
test(e2e): booking — book and cancel happy paths

### DIFF
--- a/e2e/booking.spec.ts
+++ b/e2e/booking.spec.ts
@@ -1,8 +1,89 @@
 import { expect, test } from 'e2e/utils';
 import { USER_FILE } from 'e2e/utils/constants';
 
-test.describe('Booking flow', () => {
+test.describe.serial('Booking flow', () => {
   test.use({ storageState: USER_FILE });
+
+  test('book a ride on a commute stop', async ({
+    page,
+    dashboard,
+    bookingDrawer,
+    confirmDialog,
+  }) => {
+    await page.to('/app');
+
+    const adminCard = dashboard.commuteCard({ hasText: 'Admin' });
+    await dashboard.expandCard(adminCard);
+
+    // Cancel any existing booking so we have a clean "Book" button
+    const existingCancel = dashboard.cancelButton(adminCard);
+    if ((await existingCancel.count()) > 0) {
+      await existingCancel.click();
+      await confirmDialog.confirm();
+      await expect(dashboard.bookButtons(adminCard).first()).toBeVisible();
+    }
+
+    // Click the first "Book" button
+    await dashboard.bookButtons(adminCard).first().click();
+
+    // Expect booking drawer to open
+    await bookingDrawer.expectOpen();
+
+    // Expect trip type selector and optional comment textarea to be visible
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByRole('radio').first()).toBeVisible();
+    await expect(dialog.getByRole('textbox')).toBeVisible();
+
+    // Submit the booking
+    await bookingDrawer.submit();
+
+    // Expect success toast and cancel button
+    await expect(page.getByText('Booking request sent').first()).toBeVisible();
+    await expect(dashboard.cancelButton(adminCard)).toBeVisible();
+
+    // Expect no error toast
+    await expect(
+      page.getByText('Failed to send booking request')
+    ).not.toBeVisible();
+  });
+
+  test('cancel an existing booking', async ({
+    page,
+    dashboard,
+    bookingDrawer,
+    confirmDialog,
+  }) => {
+    await page.to('/app');
+
+    const adminCard = dashboard.commuteCard({ hasText: 'Admin' });
+    await dashboard.expandCard(adminCard);
+
+    // Ensure there is a booking to cancel — create one if not already present
+    if ((await dashboard.cancelButton(adminCard).count()) === 0) {
+      await dashboard.bookButtons(adminCard).first().click();
+      await bookingDrawer.expectOpen();
+      await bookingDrawer.submit();
+      await expect(
+        page.getByText('Booking request sent').first()
+      ).toBeVisible();
+    }
+
+    // Click "Cancel" button
+    await dashboard.cancelButton(adminCard).click();
+
+    // Expect confirmation dialog with "Delete" button
+    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
+
+    // Confirm the cancellation
+    await confirmDialog.confirm();
+
+    // Expect success toast and "Book" button restored
+    await expect(page.getByText('Booking cancelled').first()).toBeVisible();
+    await expect(dashboard.bookButtons(adminCard).first()).toBeVisible();
+
+    // Expect no error toast
+    await expect(page.getByText('Failed to cancel booking')).not.toBeVisible();
+  });
 
   test('book, cancel, then book a different stop without conflict', async ({
     page,

--- a/e2e/booking.spec.ts
+++ b/e2e/booking.spec.ts
@@ -68,13 +68,8 @@ test.describe.serial('Booking flow', () => {
       ).toBeVisible();
     }
 
-    // Click "Cancel" button
+    // Click "Cancel" button and confirm the dialog
     await dashboard.cancelButton(adminCard).click();
-
-    // Expect confirmation dialog with "Delete" button
-    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
-
-    // Confirm the cancellation
     await confirmDialog.confirm();
 
     // Expect success toast and "Book" button restored


### PR DESCRIPTION
Closes #122

## Summary
- Adds `3.1 — book a ride on a commute stop`: navigates to the Admin commute card, cleans up any pre-existing booking, books a stop, and asserts the drawer UI (trip type selector, comment textarea), success toast, and Cancel button
- Adds `3.2 — cancel an existing booking`: ensures a booking exists (creates one if needed), cancels it via the confirmation dialog, and asserts the success toast and restored Book button
- Switches `test.describe` to `test.describe.serial` to prevent race conditions — all three booking tests share the same user's booking state on the Admin card

## Test plan
- [x] All three tests in `e2e/booking.spec.ts` pass