### PR TITLE
test(e2e): driver request management — accept, refuse, cancel commute

### DIFF
--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -4,3 +4,4 @@ export { DashboardPage } from './dashboard.page';
 export { LoginPage } from './login.page';
 export { LocationsPage } from './locations.page';
 export { ManagerUsersPage } from './manager-users.page';
+export { RequestsPage } from './requests.page';

--- a/e2e/pages/requests.page.ts
+++ b/e2e/pages/requests.page.ts
@@ -1,0 +1,23 @@
+import { type Locator, type Page } from '@playwright/test';
+
+import { ORG_SLUG } from 'e2e/utils/constants';
+
+export class RequestsPage {
+  constructor(private readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto(`/app/${ORG_SLUG}/requests`);
+  }
+
+  firstRequestCard(): Locator {
+    return this.page.locator('[data-slot="card"]').first();
+  }
+
+  acceptButton(card: Locator): Locator {
+    return card.getByRole('button', { name: 'Accept' });
+  }
+
+  refuseButton(card: Locator): Locator {
+    return card.getByRole('button', { name: 'Refuse' });
+  }
+}

--- a/e2e/requests.spec.ts
+++ b/e2e/requests.spec.ts
@@ -1,0 +1,94 @@
+import { type Browser } from '@playwright/test';
+
+import { expect, test } from 'e2e/utils';
+import { ADMIN_FILE, ORG_SLUG, USER_FILE } from 'e2e/utils/constants';
+import { BookingDrawer, ConfirmDialog, DashboardPage } from 'e2e/pages';
+
+/**
+ * Creates a REQUESTED booking as USER on ADMIN's commute,
+ * so the admin sees an incoming request on their requests page.
+ */
+async function ensureBookingRequest(browser: Browser) {
+  const userContext = await browser.newContext({ storageState: USER_FILE });
+  const userPage = await userContext.newPage();
+  const dashboard = new DashboardPage(userPage);
+  const bookingDrawer = new BookingDrawer(userPage);
+  const confirmDialog = new ConfirmDialog(userPage);
+
+  await userPage.goto(`/app/${ORG_SLUG}/`);
+
+  const adminCard = dashboard.commuteCard({ hasText: 'Admin' });
+  await dashboard.expandCard(adminCard);
+
+  // Cancel any existing booking so we start clean
+  if ((await dashboard.cancelButton(adminCard).count()) > 0) {
+    await dashboard.cancelButton(adminCard).click();
+    await confirmDialog.confirm();
+    await expect(userPage.getByText('Booking cancelled').first()).toBeVisible();
+  }
+
+  // Submit a booking request (status = REQUESTED)
+  await dashboard.bookButtons(adminCard).first().click();
+  await bookingDrawer.expectOpen();
+  await bookingDrawer.submit();
+  await expect(
+    userPage.getByText('Booking request sent').first()
+  ).toBeVisible();
+
+  await userContext.close();
+}
+
+test.describe.serial('Driver — Request Management', () => {
+  test.use({ storageState: ADMIN_FILE });
+
+  test('accept a booking request', async ({ browser, page, requestsPage }) => {
+    await ensureBookingRequest(browser);
+    await requestsPage.goto();
+
+    const firstCard = requestsPage.firstRequestCard();
+    await expect(firstCard).toBeVisible();
+    await expect(requestsPage.acceptButton(firstCard)).toBeVisible();
+    await expect(requestsPage.refuseButton(firstCard)).toBeVisible();
+
+    await requestsPage.acceptButton(firstCard).click();
+
+    await expect(page.getByText('Request accepted').first()).toBeVisible();
+  });
+
+  test('refuse a booking request', async ({ browser, page, requestsPage }) => {
+    await ensureBookingRequest(browser);
+    await requestsPage.goto();
+
+    const firstCard = requestsPage.firstRequestCard();
+    await expect(firstCard).toBeVisible();
+
+    await requestsPage.refuseButton(firstCard).click();
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Refuse' })
+      .click();
+
+    await expect(page.getByText('Request refused').first()).toBeVisible();
+  });
+
+  test('cancel a commute (driver)', async ({ page, confirmDialog }) => {
+    await page.goto(`/app/${ORG_SLUG}/commutes`);
+
+    // getMyCommutes returns both driven and passenger commutes, so filter for
+    // a card where the current user is the driver (has the "Driver" status badge)
+    const driverCard = page
+      .locator('[data-slot="card-commute"]')
+      .filter({ has: page.getByText('Driver') })
+      .first();
+    await expect(driverCard).toBeVisible();
+
+    await driverCard.locator('[data-slot="card-commute-trigger"]').click();
+    const content = driverCard.locator('[data-slot="card-commute-content"]');
+    await expect(content).toBeVisible();
+
+    await content.getByRole('button', { name: 'Cancel' }).click();
+    await confirmDialog.confirm();
+
+    await expect(page.getByText('Commute cancelled').first()).toBeVisible();
+  });
+});

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -6,6 +6,7 @@ import {
   LoginPage,
   LocationsPage,
   ManagerUsersPage,
+  RequestsPage,
 } from 'e2e/pages';
 import { ExtendedPage, pageWithUtils } from 'e2e/utils/page';
 
@@ -16,6 +17,7 @@ type PageFixtures = {
   confirmDialog: ConfirmDialog;
   locationsPage: LocationsPage;
   usersPage: ManagerUsersPage;
+  requestsPage: RequestsPage;
 };
 
 const testWithPage = base.extend<ExtendedPage>({
@@ -40,6 +42,9 @@ const test = testWithPage.extend<PageFixtures>({
   },
   usersPage: async ({ page }, use) => {
     await use(new ManagerUsersPage(page));
+  },
+  requestsPage: async ({ page }, use) => {
+    await use(new RequestsPage(page));
   },
 });
 

--- a/prisma/seed/commute.ts
+++ b/prisma/seed/commute.ts
@@ -94,7 +94,7 @@ export async function createCommutes(organizationId: string) {
             await db.passengersOnStops.create({
               data: {
                 tripType: type === 'ROUND' ? 'ROUND' : 'ONEWAY',
-                status: 'ACCEPTED',
+                status: 'REQUESTED',
                 passengerMemberId: otherMember.id,
                 stopId: stop.id,
               },


### PR DESCRIPTION
Closes #124

## Summary

- Adds `RequestsPage` page object (`goto`, `firstRequestCard`, `acceptButton`, `refuseButton`) and registers it as a `requestsPage` fixture
- Adds `e2e/requests.spec.ts` with three serial tests (no numbering in test names, per project convention):
  - **accept a booking request** — creates a fresh REQUESTED booking via a separate USER browser context, navigates to admin's requests page, clicks Accept, asserts "Request accepted" toast
  - **refuse a booking request** — same setup, clicks Refuse, confirms in the drawer, asserts "Request refused" toast
  - **cancel a commute (driver)** — navigates to the commutes page, filters for a card with the "Driver" badge (to skip passenger commutes also returned by `getMyCommutes`), expands, cancels, confirms, asserts "Commute cancelled" toast
- Updates seed to create `REQUESTED` (not `ACCEPTED`) bookings so the requests page pre-populates on fresh installs

## Test plan

- [x] Run `pnpm test:e2e --project chromium e2e/requests.spec.ts` against a dev server — all 3 tests pass
- [x] Confirm existing booking / location / dashboard specs still pass (no regressions)