### PR TITLE
test(e2e): commute template management — CRUD

### DIFF
--- a/e2e/commute-templates.spec.ts
+++ b/e2e/commute-templates.spec.ts
@@ -1,0 +1,166 @@
+import { expect, test } from 'e2e/utils';
+import { USER_FILE } from 'e2e/utils/constants';
+import { randomString } from 'remeda';
+
+test.describe('Commute template management', () => {
+  test.use({ storageState: USER_FILE });
+
+  test.beforeEach(async ({ commuteTemplatesPage }) => {
+    await commuteTemplatesPage.goto();
+    await expect(commuteTemplatesPage.heading).toBeVisible();
+  });
+
+  test('Create a new commute template', async ({
+    page,
+    commuteTemplatesPage,
+  }) => {
+    const name = `Home to Office ${randomString(6)}`;
+
+    await commuteTemplatesPage.newTemplateButton.click();
+    await expect(page.getByText('New Template').first()).toBeVisible();
+
+    // Step 1 — Details
+    await commuteTemplatesPage.nameInput.fill(name);
+    await commuteTemplatesPage.seatsInput.clear();
+    await commuteTemplatesPage.seatsInput.fill('2');
+
+    // Ensure round trip is checked (ROUND type)
+    const roundTrip = commuteTemplatesPage.roundTripCheckbox;
+    if (!(await roundTrip.isChecked())) {
+      await roundTrip.click();
+    }
+
+    await commuteTemplatesPage.clickNext();
+
+    // Step 2 — Outward stops (2 stops pre-populated)
+    await commuteTemplatesPage.selectLocation(0, 'Home');
+    await commuteTemplatesPage.fillOutwardTime(0, '08:00');
+    await commuteTemplatesPage.selectLocation(1, 'Office');
+    await commuteTemplatesPage.fillOutwardTime(1, '08:30');
+
+    await commuteTemplatesPage.clickNext();
+
+    // Step 3 — Inward stops (shown for ROUND; stops are displayed reversed: Office→Home)
+    // Validation requires stop[0].inwardTime > stop[1].inwardTime (Home > Office)
+    await commuteTemplatesPage.fillInwardTime(0, '18:00'); // Office (display index 0)
+    await commuteTemplatesPage.fillInwardTime(1, '18:30'); // Home (display index 1)
+
+    await commuteTemplatesPage.clickNext();
+
+    // Step 4 — Summary → submit; onSuccess navigates back to the list (no toast)
+    await commuteTemplatesPage.clickCreate();
+
+    await expect(commuteTemplatesPage.heading).toBeVisible({ timeout: 10_000 });
+    await commuteTemplatesPage.expectTemplateVisible(name);
+  });
+
+  test('Edit a commute template', async ({ page, commuteTemplatesPage }) => {
+    const originalName = `Edit Me ${randomString(6)}`;
+    const updatedName = `${originalName} - Updated`;
+
+    // Create a template with valid stop times to edit
+    await commuteTemplatesPage.newTemplateButton.click();
+
+    await commuteTemplatesPage.nameInput.fill(originalName);
+    await commuteTemplatesPage.seatsInput.clear();
+    await commuteTemplatesPage.seatsInput.fill('2');
+
+    const roundTrip = commuteTemplatesPage.roundTripCheckbox;
+    if (!(await roundTrip.isChecked())) {
+      await roundTrip.click();
+    }
+
+    await commuteTemplatesPage.clickNext();
+
+    await commuteTemplatesPage.selectLocation(0, 'Home');
+    await commuteTemplatesPage.fillOutwardTime(0, '08:00');
+    await commuteTemplatesPage.selectLocation(1, 'Office');
+    await commuteTemplatesPage.fillOutwardTime(1, '08:30');
+
+    await commuteTemplatesPage.clickNext();
+
+    await commuteTemplatesPage.fillInwardTime(0, '18:00'); // Office (display index 0)
+    await commuteTemplatesPage.fillInwardTime(1, '18:30'); // Home (display index 1)
+
+    await commuteTemplatesPage.clickNext();
+
+    await commuteTemplatesPage.clickCreate();
+
+    // Wait for navigation back to the list before editing
+    await expect(commuteTemplatesPage.heading).toBeVisible({ timeout: 10_000 });
+    await commuteTemplatesPage.expectTemplateVisible(originalName);
+
+    // Now edit the created template
+    await commuteTemplatesPage.clickTemplateCard(originalName);
+    await expect(page.getByText('Next').first()).toBeVisible();
+
+    // Step 1 — Details: update name and seats
+    await commuteTemplatesPage.nameInput.clear();
+    await commuteTemplatesPage.nameInput.fill(updatedName);
+    await commuteTemplatesPage.seatsInput.clear();
+    await commuteTemplatesPage.seatsInput.fill('4');
+
+    await commuteTemplatesPage.clickNext();
+
+    // Step 2 — Outward stops: valid times already in place, skip through
+    await commuteTemplatesPage.clickNext();
+
+    // Step 3 — Inward stops: valid times already in place, skip through
+    await commuteTemplatesPage.clickNext();
+
+    // Step 4 — Summary → save; onSuccess navigates back to the list (no toast)
+    await commuteTemplatesPage.clickSave();
+
+    await expect(commuteTemplatesPage.heading).toBeVisible({ timeout: 10_000 });
+    await commuteTemplatesPage.expectTemplateVisible(updatedName);
+  });
+
+  test('Delete a commute template', async ({
+    page,
+    commuteTemplatesPage,
+    confirmDialog,
+  }) => {
+    const name = `To Delete ${randomString(6)}`;
+
+    // Create a ONEWAY template to delete (no inward stops step)
+    await commuteTemplatesPage.newTemplateButton.click();
+
+    await commuteTemplatesPage.nameInput.fill(name);
+    await commuteTemplatesPage.seatsInput.clear();
+    await commuteTemplatesPage.seatsInput.fill('1');
+
+    // Uncheck round trip for ONEWAY
+    const roundTrip = commuteTemplatesPage.roundTripCheckbox;
+    if (await roundTrip.isChecked()) {
+      await roundTrip.click();
+    }
+
+    await commuteTemplatesPage.clickNext();
+
+    await commuteTemplatesPage.selectLocation(0, 'Home');
+    await commuteTemplatesPage.fillOutwardTime(0, '07:00');
+    await commuteTemplatesPage.selectLocation(1, 'Office');
+    await commuteTemplatesPage.fillOutwardTime(1, '07:30');
+
+    await commuteTemplatesPage.clickNext();
+
+    // ONEWAY has no inward stops step — next lands on Summary
+    await commuteTemplatesPage.clickCreate();
+
+    // Wait for navigation back to the list (no toast on create)
+    await expect(commuteTemplatesPage.heading).toBeVisible({ timeout: 10_000 });
+    await commuteTemplatesPage.expectTemplateVisible(name);
+
+    // Delete it
+    await commuteTemplatesPage.clickDeleteOnRow(name);
+    await expect(
+      page.getByText('You are about to delete this template.').first()
+    ).toBeVisible();
+    await confirmDialog.confirm();
+
+    await expect(page.getByText('Template deleted').first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await commuteTemplatesPage.expectTemplateNotVisible(name);
+  });
+});

--- a/e2e/pages/commute-templates.page.ts
+++ b/e2e/pages/commute-templates.page.ts
@@ -1,0 +1,93 @@
+import { expect, type Page } from '@playwright/test';
+
+import { ORG_SLUG } from 'e2e/utils/constants';
+
+export class CommuteTemplatesPage {
+  constructor(private readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto(`/app/${ORG_SLUG}/account/commute-templates`);
+    // Wait for auth + org guard to resolve before asserting page content
+    await this.page.getByTestId('layout-app').waitFor({ timeout: 15_000 });
+  }
+
+  get heading() {
+    return this.page.getByText('Commute Templates').first();
+  }
+
+  get newTemplateButton() {
+    return this.page.getByRole('link', { name: 'New Template' });
+  }
+
+  templateCard(name: string) {
+    // Use data-slot="card" to scope to the card-level element only (not ancestor wrappers)
+    return this.page
+      .locator('[data-slot="card"]')
+      .filter({ has: this.page.getByText(name, { exact: true }) })
+      .first();
+  }
+
+  async clickDeleteOnRow(templateName: string) {
+    await this.templateCard(templateName)
+      .getByRole('button', { name: 'Delete', exact: true })
+      .click();
+  }
+
+  async clickTemplateCard(templateName: string) {
+    await this.templateCard(templateName)
+      .getByText(templateName, { exact: true })
+      .click();
+  }
+
+  // Multi-step form helpers
+
+  get nameInput() {
+    return this.page.getByLabel('Name');
+  }
+
+  get seatsInput() {
+    return this.page.getByLabel('Seats');
+  }
+
+  get roundTripCheckbox() {
+    return this.page.getByRole('checkbox', { name: 'Round trip' });
+  }
+
+  async selectLocation(stopIndex: number, locationName: string) {
+    const comboboxes = this.page.getByRole('combobox', { name: 'Location' });
+    await comboboxes.nth(stopIndex).click();
+    await this.page
+      .getByRole('option', { name: locationName, exact: true })
+      .click();
+  }
+
+  async fillOutwardTime(stopIndex: number, time: string) {
+    const timeInputs = this.page.getByLabel('Outbound time');
+    await timeInputs.nth(stopIndex).fill(time);
+  }
+
+  async fillInwardTime(stopIndex: number, time: string) {
+    const timeInputs = this.page.getByLabel('Inbound time');
+    await timeInputs.nth(stopIndex).fill(time);
+  }
+
+  async clickNext() {
+    await this.page.getByRole('button', { name: 'Next' }).click();
+  }
+
+  async clickCreate() {
+    await this.page.getByRole('button', { name: 'Create' }).click();
+  }
+
+  async clickSave() {
+    await this.page.getByRole('button', { name: 'Save' }).click();
+  }
+
+  async expectTemplateVisible(name: string) {
+    await expect(this.page.getByText(name).first()).toBeVisible();
+  }
+
+  async expectTemplateNotVisible(name: string) {
+    await expect(this.page.getByText(name)).not.toBeVisible();
+  }
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,4 +1,5 @@
 export { BookingDrawer } from './booking-drawer.page';
+export { CommuteTemplatesPage } from './commute-templates.page';
 export { ConfirmDialog } from './confirm-dialog.page';
 export { DashboardPage } from './dashboard.page';
 export { LoginPage } from './login.page';

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,6 +1,7 @@
 import { test as base } from '@playwright/test';
 import {
   BookingDrawer,
+  CommuteTemplatesPage,
   ConfirmDialog,
   DashboardPage,
   LoginPage,
@@ -14,6 +15,7 @@ type PageFixtures = {
   dashboard: DashboardPage;
   bookingDrawer: BookingDrawer;
   confirmDialog: ConfirmDialog;
+  commuteTemplatesPage: CommuteTemplatesPage;
   locationsPage: LocationsPage;
   usersPage: ManagerUsersPage;
 };
@@ -34,6 +36,9 @@ const test = testWithPage.extend<PageFixtures>({
   },
   confirmDialog: async ({ page }, use) => {
     await use(new ConfirmDialog(page));
+  },
+  commuteTemplatesPage: async ({ page }, use) => {
+    await use(new CommuteTemplatesPage(page));
   },
   locationsPage: async ({ page }, use) => {
     await use(new LocationsPage(page));


### PR DESCRIPTION
Closes #126

## Summary

- Adds `e2e/commute-templates.spec.ts` with 3 tests covering the happy-path spec §7: create a ROUND trip template, edit a template, delete a template
- Adds `e2e/pages/commute-templates.page.ts` — `CommuteTemplatesPage` POM with helpers for the multi-step form (location combobox, outward/inward time inputs, round trip checkbox) and card interactions
- Registers `commuteTemplatesPage` fixture in `e2e/utils/index.ts` and exports the POM from `e2e/pages/index.ts`

## Test plan

- [x] Run `pnpm playwright test e2e/commute-templates.spec.ts` and confirm all 3 tests pass
- [x] Verify create test: ROUND trip template with 2 stops, valid outward (08:00 → 08:30) and inward (Office 18:00, Home 18:30) times — navigates back to list with card visible
- [x] Verify edit test: creates a fresh template, edits name + seats, confirms updated card on list
- [x] Verify delete test: creates a ONEWAY template, deletes it via confirm dialog, confirms "Template deleted" toast and card removed