### PR TITLE
test(e2e): commute creation — from scratch and from template

### DIFF
--- a/e2e/commute.spec.ts
+++ b/e2e/commute.spec.ts
@@ -1,0 +1,193 @@
+import dayjs from 'dayjs';
+import { expect, test } from 'e2e/utils';
+import { USER_FILE } from 'e2e/utils/constants';
+import { randomString } from 'remeda';
+
+/** Format a date for the DateInput (DD/MM/YYYY). */
+function formatDate(date: Date): string {
+  return dayjs(date).format('DD/MM/YYYY');
+}
+
+/** Return a date N days from today. */
+function daysFromNow(n: number): Date {
+  return dayjs().add(n, 'day').toDate();
+}
+
+test.describe('Commute creation', () => {
+  test.use({ storageState: USER_FILE });
+
+  test.beforeEach(async ({ commuteFormPage }) => {
+    await commuteFormPage.goto();
+  });
+
+  test('Create a one-way commute from scratch', async ({
+    page,
+    commuteFormPage,
+  }) => {
+    const date = daysFromNow(14);
+    const dateStr = formatDate(date);
+
+    // Step 1 — Template picker: start from scratch
+    await commuteFormPage.fromScratchButton.click();
+
+    // Step 2 — Details
+    await commuteFormPage.dateInput.fill(dateStr);
+    await commuteFormPage.dateInput.blur();
+
+    // Uncheck round trip for ONEWAY
+    const roundTrip = commuteFormPage.roundTripCheckbox;
+    if (await roundTrip.isChecked()) {
+      await roundTrip.click();
+    }
+
+    await commuteFormPage.seatsInput.clear();
+    await commuteFormPage.seatsInput.fill('2');
+
+    await commuteFormPage.clickNext();
+
+    // Step 3 — Outward stops (2 stops pre-populated)
+    await commuteFormPage.selectLocation(0, 'Home');
+    await commuteFormPage.fillOutwardTime(0, '08:00');
+    await commuteFormPage.selectLocation(1, 'Office');
+    await commuteFormPage.fillOutwardTime(1, '08:30');
+
+    await commuteFormPage.clickNext();
+
+    // Step 4 — Recap (no inward stops for ONEWAY)
+    await expect(page.getByText('One way').first()).toBeVisible();
+    await expect(page.getByText('2 seats').first()).toBeVisible();
+
+    await commuteFormPage.clickCreate();
+
+    // Expect redirect to commutes list
+    await expect(commuteFormPage.commutesListHeading).toBeVisible({
+      timeout: 10_000,
+    });
+    await commuteFormPage.expectCommuteInList();
+  });
+
+  test('Create a round-trip commute from scratch', async ({
+    page,
+    commuteFormPage,
+  }) => {
+    const date = daysFromNow(15);
+    const dateStr = formatDate(date);
+
+    // Step 1 — Template picker: start from scratch
+    await commuteFormPage.fromScratchButton.click();
+
+    // Step 2 — Details
+    await commuteFormPage.dateInput.fill(dateStr);
+    await commuteFormPage.dateInput.blur();
+
+    // Ensure round trip is checked (ROUND type)
+    const roundTrip = commuteFormPage.roundTripCheckbox;
+    if (!(await roundTrip.isChecked())) {
+      await roundTrip.click();
+    }
+
+    await commuteFormPage.seatsInput.clear();
+    await commuteFormPage.seatsInput.fill('3');
+
+    await commuteFormPage.clickNext();
+
+    // Step 3 — Outward stops
+    await commuteFormPage.selectLocation(0, 'Home');
+    await commuteFormPage.fillOutwardTime(0, '08:00');
+    await commuteFormPage.selectLocation(1, 'Office');
+    await commuteFormPage.fillOutwardTime(1, '08:30');
+
+    await commuteFormPage.clickNext();
+
+    // Step 4 — Inward times (ROUND only; stops shown in reverse: Office→Home)
+    await commuteFormPage.fillInwardTime(0, '18:30'); // Office (display index 0)
+    await commuteFormPage.fillInwardTime(1, '19:00'); // Home (display index 1)
+
+    await commuteFormPage.clickNext();
+
+    // Step 5 — Recap
+    await expect(page.getByText('Round trip').first()).toBeVisible();
+    await expect(page.getByText('3 seats').first()).toBeVisible();
+
+    await commuteFormPage.clickCreate();
+
+    // Expect redirect to commutes list
+    await expect(commuteFormPage.commutesListHeading).toBeVisible({
+      timeout: 10_000,
+    });
+    await commuteFormPage.expectCommuteInList();
+  });
+
+  test('Create a commute from a saved template', async ({
+    page,
+    commuteFormPage,
+    commuteTemplatesPage,
+  }) => {
+    // Pre-condition: create a valid ROUND template with proper time ordering
+    const templateName = `Commute Template ${randomString(6)}`;
+
+    await commuteTemplatesPage.goto();
+    await commuteTemplatesPage.newTemplateButton.click();
+
+    await commuteTemplatesPage.nameInput.fill(templateName);
+    await commuteTemplatesPage.seatsInput.clear();
+    await commuteTemplatesPage.seatsInput.fill('2');
+
+    const roundTrip = commuteTemplatesPage.roundTripCheckbox;
+    if (!(await roundTrip.isChecked())) {
+      await roundTrip.click();
+    }
+
+    await commuteTemplatesPage.clickNext();
+
+    await commuteTemplatesPage.selectLocation(0, 'Home');
+    await commuteTemplatesPage.fillOutwardTime(0, '08:00');
+    await commuteTemplatesPage.selectLocation(1, 'Office');
+    await commuteTemplatesPage.fillOutwardTime(1, '08:30');
+
+    await commuteTemplatesPage.clickNext();
+
+    // Inward times (ROUND; stops in reverse: Office→Home)
+    await commuteTemplatesPage.fillInwardTime(0, '18:30'); // Office
+    await commuteTemplatesPage.fillInwardTime(1, '19:00'); // Home
+
+    await commuteTemplatesPage.clickNext();
+    await commuteTemplatesPage.clickCreate();
+
+    await expect(commuteTemplatesPage.heading).toBeVisible({ timeout: 10_000 });
+
+    // Navigate to commute creation and pick the template
+    const date = daysFromNow(16);
+    const dateStr = formatDate(date);
+
+    await commuteFormPage.goto();
+
+    // Step 1 — Template picker: select the template we just created
+    await expect(page.getByText('My templates').first()).toBeVisible();
+    await commuteFormPage.selectTemplate(templateName);
+
+    // Step 2 — Details: fields pre-populated from template; update the date
+    await commuteFormPage.dateInput.fill(dateStr);
+    await commuteFormPage.dateInput.blur();
+
+    await commuteFormPage.clickNext();
+
+    // Step 3 — Outward stops pre-populated from template (Home 08:00, Office 08:30)
+    await commuteFormPage.clickNext();
+
+    // Step 4 — Inward times pre-populated from template (Office 18:30, Home 19:00)
+    await commuteFormPage.clickNext();
+
+    // Step 5 — Recap
+    await expect(page.getByText('Round trip').first()).toBeVisible();
+    await expect(page.getByText('2 seats').first()).toBeVisible();
+
+    await commuteFormPage.clickCreate();
+
+    // Expect redirect to commutes list
+    await expect(commuteFormPage.commutesListHeading).toBeVisible({
+      timeout: 10_000,
+    });
+    await commuteFormPage.expectCommuteInList();
+  });
+});

--- a/e2e/pages/commute-form.page.ts
+++ b/e2e/pages/commute-form.page.ts
@@ -1,0 +1,77 @@
+import { expect, type Page } from '@playwright/test';
+
+import { ORG_SLUG } from 'e2e/utils/constants';
+
+export class CommuteFormPage {
+  constructor(private readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto(`/app/${ORG_SLUG}/commutes/new`);
+    await this.page.getByTestId('layout-app').waitFor({ timeout: 15_000 });
+  }
+
+  // ─── Template picker screen ───────────────────────────────────────────
+
+  get fromScratchButton() {
+    return this.page.getByRole('button', { name: 'Create from scratch' });
+  }
+
+  /** Click a template card by its name to start from a template. */
+  async selectTemplate(templateName: string) {
+    await this.page
+      .locator('[data-slot="card"]')
+      .filter({ has: this.page.getByText(templateName) })
+      .first()
+      .click();
+  }
+
+  // ─── Multi-step form ──────────────────────────────────────────────────
+
+  get dateInput() {
+    return this.page.getByLabel('Date');
+  }
+
+  get roundTripCheckbox() {
+    return this.page.getByRole('checkbox', { name: 'Round trip' });
+  }
+
+  get seatsInput() {
+    return this.page.getByLabel('Seats');
+  }
+
+  async selectLocation(stopIndex: number, locationName: string) {
+    const comboboxes = this.page.getByRole('combobox', { name: 'Location' });
+    await comboboxes.nth(stopIndex).click();
+    await this.page
+      .getByRole('option', { name: locationName, exact: true })
+      .click();
+  }
+
+  async fillOutwardTime(stopIndex: number, time: string) {
+    await this.page.getByLabel('Outbound time').nth(stopIndex).fill(time);
+  }
+
+  async fillInwardTime(stopIndex: number, time: string) {
+    await this.page.getByLabel('Inbound time').nth(stopIndex).fill(time);
+  }
+
+  async clickNext() {
+    await this.page.getByRole('button', { name: 'Next' }).click();
+  }
+
+  async clickCreate() {
+    await this.page.getByRole('button', { name: 'Create' }).click();
+  }
+
+  // ─── Commutes list assertions ─────────────────────────────────────────
+
+  get commutesListHeading() {
+    return this.page.getByText('Commutes').first();
+  }
+
+  async expectCommuteInList() {
+    await expect(
+      this.page.locator('[data-slot="card-commute"]').first()
+    ).toBeVisible({ timeout: 10_000 });
+  }
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,4 +1,5 @@
 export { BookingDrawer } from './booking-drawer.page';
+export { CommuteFormPage } from './commute-form.page';
 export { CommuteTemplatesPage } from './commute-templates.page';
 export { ConfirmDialog } from './confirm-dialog.page';
 export { DashboardPage } from './dashboard.page';

--- a/e2e/pages/locations.page.ts
+++ b/e2e/pages/locations.page.ts
@@ -7,6 +7,7 @@ export class LocationsPage {
 
   async goto() {
     await this.page.goto(`/app/${ORG_SLUG}/account/locations`);
+    await this.page.getByTestId('layout-app').waitFor({ timeout: 15_000 });
   }
 
   get heading() {

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,6 +1,7 @@
 import { test as base } from '@playwright/test';
 import {
   BookingDrawer,
+  CommuteFormPage,
   CommuteTemplatesPage,
   ConfirmDialog,
   DashboardPage,
@@ -16,6 +17,7 @@ type PageFixtures = {
   dashboard: DashboardPage;
   bookingDrawer: BookingDrawer;
   confirmDialog: ConfirmDialog;
+  commuteFormPage: CommuteFormPage;
   commuteTemplatesPage: CommuteTemplatesPage;
   locationsPage: LocationsPage;
   usersPage: ManagerUsersPage;
@@ -38,6 +40,9 @@ const test = testWithPage.extend<PageFixtures>({
   },
   confirmDialog: async ({ page }, use) => {
     await use(new ConfirmDialog(page));
+  },
+  commuteFormPage: async ({ page }, use) => {
+    await use(new CommuteFormPage(page));
   },
   commuteTemplatesPage: async ({ page }, use) => {
     await use(new CommuteTemplatesPage(page));


### PR DESCRIPTION
Closes #123

## Summary
- Add `CommuteFormPage` page object with helpers for the template picker, multi-step form (date, round-trip checkbox, seats, location dropdowns, time inputs), and commutes list assertions
- Add `e2e/commute.spec.ts` with 3 scenarios: ONEWAY from scratch, ROUND from scratch, and from a saved template
- Fix `LocationsPage.goto()` to wait for `layout-app` before returning, preventing a race condition in `beforeEach`

## Test plan
- [x] Create a one-way commute from scratch (2 stops, ONEWAY type, future date)
- [x] Create a round-trip commute from scratch (2 stops, ROUND type, inward times)
- [x] Create a commute from a saved template (template created inline as pre-condition)