### PR TITLE
test(e2e): account settings — personal info and auto-accept

### DIFF
--- a/e2e/account.spec.ts
+++ b/e2e/account.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'e2e/utils';
+import { USER_FILE } from 'e2e/utils/constants';
+
+test.describe.serial('Account settings', () => {
+  test.use({ storageState: USER_FILE });
+
+  test.beforeEach(async ({ accountPage }) => {
+    await accountPage.goto();
+    await expect(accountPage.heading).toBeVisible();
+  });
+
+  test('Update personal information', async ({ page, accountPage }) => {
+    await accountPage.editNameButton.click();
+    await expect(page.getByText('Update your name').first()).toBeVisible();
+
+    await accountPage.nameInput.clear();
+    await accountPage.nameInput.fill('Updated User');
+    await accountPage.updateButton.click();
+
+    await expect(page.getByText('Name updated').first()).toBeVisible();
+    await accountPage.expectNameVisible('Updated User');
+  });
+
+  test('Enable auto-accept', async ({ page, accountPage }) => {
+    const checkbox = accountPage.autoAcceptCheckbox;
+
+    if (await checkbox.isChecked()) {
+      await checkbox.click();
+      await expect(page.getByText('Auto-accept updated').first()).toBeVisible();
+    }
+
+    await checkbox.click();
+    await expect(page.getByText('Auto-accept updated').first()).toBeVisible();
+    await expect(checkbox).toBeChecked();
+
+    await accountPage.goto();
+    await expect(accountPage.heading).toBeVisible();
+    await expect(accountPage.autoAcceptCheckbox).toBeChecked();
+  });
+
+  test('Disable auto-accept', async ({ page, accountPage }) => {
+    const checkbox = accountPage.autoAcceptCheckbox;
+
+    if (!(await checkbox.isChecked())) {
+      await checkbox.click();
+      await expect(page.getByText('Auto-accept updated').first()).toBeVisible();
+    }
+
+    await checkbox.click();
+    await expect(page.getByText('Auto-accept updated').first()).toBeVisible();
+    await expect(checkbox).not.toBeChecked();
+  });
+});

--- a/e2e/pages/account.page.ts
+++ b/e2e/pages/account.page.ts
@@ -1,0 +1,40 @@
+import { expect, type Page } from '@playwright/test';
+
+import { ORG_SLUG } from 'e2e/utils/constants';
+
+export class AccountPage {
+  constructor(private readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto(`/app/${ORG_SLUG}/account`);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  get heading() {
+    return this.page.locator('[data-testid="layout-app"]');
+  }
+
+  get editNameButton() {
+    return this.page.getByRole('button', { name: 'Update your name' });
+  }
+
+  get nameInput() {
+    return this.page
+      .getByRole('dialog', { name: 'Update your name' })
+      .getByRole('textbox');
+  }
+
+  get updateButton() {
+    return this.page.getByRole('button', { name: 'Update' });
+  }
+
+  get autoAcceptCheckbox() {
+    return this.page.getByRole('checkbox', {
+      name: 'Automatically accept ride requests',
+    });
+  }
+
+  async expectNameVisible(name: string) {
+    await expect(this.page.getByText(name).first()).toBeVisible();
+  }
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,3 +1,4 @@
+export { AccountPage } from './account.page';
 export { BookingDrawer } from './booking-drawer.page';
 export { CommuteTemplatesPage } from './commute-templates.page';
 export { ConfirmDialog } from './confirm-dialog.page';

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,5 +1,6 @@
 import { test as base } from '@playwright/test';
 import {
+  AccountPage,
   BookingDrawer,
   CommuteTemplatesPage,
   ConfirmDialog,
@@ -12,6 +13,7 @@ import {
 import { ExtendedPage, pageWithUtils } from 'e2e/utils/page';
 
 type PageFixtures = {
+  accountPage: AccountPage;
   loginPage: LoginPage;
   dashboard: DashboardPage;
   bookingDrawer: BookingDrawer;
@@ -27,6 +29,9 @@ const testWithPage = base.extend<ExtendedPage>({
 });
 
 const test = testWithPage.extend<PageFixtures>({
+  accountPage: async ({ page }, use) => {
+    await use(new AccountPage(page));
+  },
   loginPage: async ({ page }, use) => {
     await use(new LoginPage(page));
   },


### PR DESCRIPTION
Closes #127

## Summary

- Adds `AccountPage` page object (`e2e/pages/account.page.ts`) with selectors for the edit-name drawer, auto-accept checkbox, and layout heading
- Adds `accountPage` fixture to the shared test utils
- Adds `e2e/account.spec.ts` with three scenarios from §8 of `happy-path.md`:
  - **Update personal information** — opens the edit-name drawer, updates the name, asserts toast and new name on page
  - **Enable auto-accept** — toggles the checkbox on, asserts toast + checked state, re-navigates and asserts persistence
  - **Disable auto-accept** — ensures toggle is on first, then disables it, asserts toast + unchecked state

## Notes

- Uses `test.describe.serial` to prevent parallel workers from racing on the shared `autoAccept` DB field
- Persistence check uses `accountPage.goto()` (full navigation + `waitForLoadState('networkidle')`) rather than `page.reload()` for reliable SPA re-initialization
- `nameInput` is scoped to `getByRole('dialog', { name: 'Update your name' })` to avoid strict-mode ambiguity with the page-level "Name" label

## Test plan

- [ ] Run `pnpm e2e account` — all 3 tests pass