### PR TITLE
feat(e2e): manager organization — view details and update settings

### DIFF
--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'e2e/utils';
+import { ADMIN_EMAIL, ADMIN_FILE } from 'e2e/utils/constants';
+import { randomString } from 'remeda';
+
+test.describe.serial('Manager organization', () => {
+  test.use({ storageState: ADMIN_FILE });
+
+  test('View organization details', async ({ page, managerOrgPage }) => {
+    await managerOrgPage.gotoOrgDashboard();
+
+    await expect(page.locator('[data-testid="layout-manager"]')).toBeVisible();
+
+    await managerOrgPage.expectOrgNameVisible('Default Organization');
+    await managerOrgPage.expectMembersSectionVisible();
+    await managerOrgPage.expectMemberRowVisible({ email: ADMIN_EMAIL });
+    await managerOrgPage.expectPendingInvitationsSectionVisible();
+  });
+
+  test('Update organization settings', async ({ page, managerOrgPage }) => {
+    await managerOrgPage.gotoAccount();
+
+    await expect(managerOrgPage.orgSettingsCard).toBeVisible();
+
+    const newName = `Default Organization ${randomString(6)}`;
+
+    await managerOrgPage.nameInput.fill(newName);
+    await managerOrgPage.saveButton.click();
+
+    await expect(page.getByText('Organization updated').first()).toBeVisible();
+
+    // Restore original name
+    await managerOrgPage.nameInput.fill('Default Organization');
+    await managerOrgPage.saveButton.click();
+    await expect(page.getByText('Organization updated').first()).toBeVisible();
+  });
+});

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -6,5 +6,6 @@ export { ConfirmDialog } from './confirm-dialog.page';
 export { DashboardPage } from './dashboard.page';
 export { LoginPage } from './login.page';
 export { LocationsPage } from './locations.page';
+export { ManagerOrgPage } from './manager-org.page';
 export { ManagerUsersPage } from './manager-users.page';
 export { RequestsPage } from './requests.page';

--- a/e2e/pages/manager-org.page.ts
+++ b/e2e/pages/manager-org.page.ts
@@ -1,0 +1,47 @@
+import { expect, type Page } from '@playwright/test';
+
+import { ORG_SLUG } from 'e2e/utils/constants';
+
+export class ManagerOrgPage {
+  constructor(private readonly page: Page) {}
+
+  async gotoOrgDashboard() {
+    await this.page.goto(`/manager/${ORG_SLUG}`);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async gotoAccount() {
+    await this.page.goto(`/manager/${ORG_SLUG}/account`);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  get orgSettingsCard() {
+    return this.page.getByText('Organization Settings').first();
+  }
+
+  get nameInput() {
+    return this.page.getByLabel('Name');
+  }
+
+  get saveButton() {
+    return this.page.getByRole('button', { name: 'Save' });
+  }
+
+  async expectOrgNameVisible(name: string) {
+    await expect(this.page.getByText(name).first()).toBeVisible();
+  }
+
+  async expectMembersSectionVisible() {
+    await expect(this.page.getByText('Members').first()).toBeVisible();
+  }
+
+  async expectPendingInvitationsSectionVisible() {
+    await expect(
+      this.page.getByText('Pending invitations').first()
+    ).toBeVisible();
+  }
+
+  async expectMemberRowVisible(opts: { email: string }) {
+    await expect(this.page.getByText(opts.email).first()).toBeVisible();
+  }
+}

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -8,6 +8,7 @@ import {
   DashboardPage,
   LoginPage,
   LocationsPage,
+  ManagerOrgPage,
   ManagerUsersPage,
   RequestsPage,
 } from 'e2e/pages';
@@ -22,6 +23,7 @@ type PageFixtures = {
   commuteFormPage: CommuteFormPage;
   commuteTemplatesPage: CommuteTemplatesPage;
   locationsPage: LocationsPage;
+  managerOrgPage: ManagerOrgPage;
   usersPage: ManagerUsersPage;
   requestsPage: RequestsPage;
 };
@@ -54,6 +56,9 @@ const test = testWithPage.extend<PageFixtures>({
   },
   locationsPage: async ({ page }, use) => {
     await use(new LocationsPage(page));
+  },
+  managerOrgPage: async ({ page }, use) => {
+    await use(new ManagerOrgPage(page));
   },
   usersPage: async ({ page }, use) => {
     await use(new ManagerUsersPage(page));

--- a/src/features/account/manager/page-account.tsx
+++ b/src/features/account/manager/page-account.tsx
@@ -7,6 +7,7 @@ import { MemberPreferences } from '@/features/account/member-preferences';
 import { UserCard } from '@/features/account/user-card';
 import { BuildInfoDrawer } from '@/features/build-info/build-info-drawer';
 import { BuildInfoVersion } from '@/features/build-info/build-info-version';
+import { OrgSettingsCard } from '@/features/organization/manager/org-settings-card';
 import {
   PageLayout,
   PageLayoutContent,
@@ -35,6 +36,7 @@ export const PageAccount = () => {
             <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
               {t('account:sections.organization')}
             </h2>
+            <OrgSettingsCard />
             <MemberPreferences />
           </section>
 

--- a/src/features/organization/manager/org-settings-card.tsx
+++ b/src/features/organization/manager/org-settings-card.tsx
@@ -1,0 +1,98 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { FormStateSubscribe, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { orpc } from '@/lib/orpc/client';
+
+import {
+  Form,
+  FormField,
+  FormFieldController,
+  FormFieldLabel,
+} from '@/components/form';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const zFormFields = z.object({
+  name: z.string().min(1).max(100),
+});
+
+type FormFields = z.infer<typeof zFormFields>;
+
+export const OrgSettingsCard = () => {
+  const { t } = useTranslation(['organization']);
+  const queryClient = useQueryClient();
+
+  const orgQuery = useQuery(
+    orpc.organization.getActiveOrganization.queryOptions()
+  );
+
+  const form = useForm<FormFields>({
+    resolver: zodResolver(zFormFields),
+    values: { name: orgQuery.data?.name ?? '' },
+  });
+
+  const updateOrg = useMutation(
+    orpc.organization.update.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: orpc.organization.getActiveOrganization.key(),
+        });
+        form.reset({ name: form.getValues('name') });
+        toast.success(t('organization:manager.account.updateSuccess'));
+      },
+      onError: () => {
+        toast.error(t('organization:manager.account.updateError'));
+      },
+    })
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('organization:manager.account.title')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {orgQuery.isPending ? (
+          <Skeleton className="h-10 w-full" />
+        ) : (
+          <Form
+            {...form}
+            onSubmit={(values) => updateOrg.mutate(values)}
+            className="gap-4"
+          >
+            <FormField>
+              <FormFieldLabel>
+                {t('organization:manager.account.nameLabel')}
+              </FormFieldLabel>
+              <FormFieldController
+                type="text"
+                control={form.control}
+                name="name"
+              />
+            </FormField>
+
+            <div className="flex justify-end">
+              <FormStateSubscribe
+                control={form.control}
+                render={({ isDirty }) => (
+                  <Button
+                    type="submit"
+                    disabled={updateOrg.isPending || !isDirty}
+                    loading={updateOrg.isPending}
+                  >
+                    {t('organization:manager.account.save')}
+                  </Button>
+                )}
+              />
+            </div>
+          </Form>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/locales/en/organization.json
+++ b/src/locales/en/organization.json
@@ -70,6 +70,13 @@
     "new": {
       "createError": "Failed to create organization"
     },
+    "account": {
+      "title": "Organization Settings",
+      "nameLabel": "Name",
+      "save": "Save",
+      "updateSuccess": "Organization updated",
+      "updateError": "Failed to update organization"
+    },
     "detail": {
       "memberCount_one": "{{count}} member",
       "memberCount_other": "{{count}} members",

--- a/src/locales/fr/organization.json
+++ b/src/locales/fr/organization.json
@@ -70,6 +70,13 @@
     "new": {
       "createError": "Impossible de créer l'organisation"
     },
+    "account": {
+      "title": "Paramètres de l'organisation",
+      "nameLabel": "Nom",
+      "save": "Enregistrer",
+      "updateSuccess": "Organisation mise à jour",
+      "updateError": "Impossible de mettre à jour l'organisation"
+    },
     "detail": {
       "memberCount_one": "{{count}} membre",
       "memberCount_other": "{{count}} membres",

--- a/src/server/repositories/organization.repository.ts
+++ b/src/server/repositories/organization.repository.ts
@@ -80,5 +80,8 @@ export const createOrganizationRepository = (db: AppDB) => ({
   findSlugById: (id: string) =>
     db.organization.findUnique({ where: { id }, select: { slug: true } }),
 
+  update: (id: string, data: { name: string }) =>
+    db.organization.update({ where: { id }, data }),
+
   delete: (id: string) => db.organization.delete({ where: { id } }),
 });

--- a/src/server/routers/organization.ts
+++ b/src/server/routers/organization.ts
@@ -307,6 +307,24 @@ export default {
       });
     }),
 
+  update: orgProcedure({ permissions: { organization: ['update'] } })
+    .route({ method: 'POST', path: '/organizations/update', tags })
+    .input(z.object({ name: z.string().min(1).max(100) }))
+    .output(z.object({ id: z.string(), name: z.string() }))
+    .handler(async ({ context, input }) => {
+      const result = await context.organizations.update(
+        context.organizationId,
+        { name: input.name }
+      );
+
+      context.logger.info(
+        { organizationId: context.organizationId },
+        'Organization updated'
+      );
+
+      return result;
+    }),
+
   delete: adminProcedure({ permission: { organization: ['delete'] } })
     .route({ method: 'POST', path: '/organizations/delete', tags })
     .input(z.object({ organizationId: z.string() }))


### PR DESCRIPTION
Closes #129

## Summary
- Add `organization.update` ORPC endpoint and repository method to update org name
- Add `OrgSettingsCard` component to the manager account page (`/manager/<orgSlug>/account`) with a pre-filled Name field and Save button
- Add `ManagerOrgPage` page object and `managerOrgPage` fixture
- Add `e2e/organizations.spec.ts` covering scenarios 10.1 and 10.2

## Test plan
- [x] 10.1 View organization details: navigates to `/manager/default`, checks org name ("Default Organization"), Members section, member row with admin email, and Pending invitations section
- [x] 10.2 Update organization settings: navigates to `/manager/default/account`, fills new org name, clicks Save, expects "Organization updated" toast, then restores original name