### PR TITLE
test(e2e): invitation flow — accept an organization invitation

### DIFF
--- a/e2e/invitations.spec.ts
+++ b/e2e/invitations.spec.ts
@@ -1,0 +1,96 @@
+import { type Browser } from '@playwright/test';
+
+import { expect, test } from 'e2e/utils';
+import { ADMIN_FILE, INVITED_EMAIL, INVITED_FILE } from 'e2e/utils/constants';
+
+type Invitation = { id: string; email: string; status: string };
+type Member = { user: { email: string } };
+
+/**
+ * Sets up a fresh pending invitation for INVITED_EMAIL in the default org.
+ *
+ * - Cancels any existing pending invitation for that email.
+ * - Removes the user from the org if they are already a member.
+ * - Creates a new invitation and returns its ID.
+ */
+async function ensureInvitation(browser: Browser): Promise<string> {
+  const adminContext = await browser.newContext({ storageState: ADMIN_FILE });
+
+  try {
+    // 1. Get current org state
+    const orgResp = await adminContext.request.get(
+      '/api/rest/organizations/active'
+    );
+    const org = await orgResp.json();
+
+    // 2. Cancel any existing invitation for INVITED_EMAIL
+    const existingInvitation = (
+      org.invitations as Invitation[] | undefined
+    )?.find((i) => i.email === INVITED_EMAIL);
+    if (existingInvitation) {
+      await adminContext.request.post(
+        '/api/rest/organizations/cancel-invitation',
+        { data: { invitationId: existingInvitation.id } }
+      );
+    }
+
+    // 3. Remove INVITED_EMAIL from org members if present
+    const existingMember = (org.members as Member[] | undefined)?.find(
+      (m) => m.user.email === INVITED_EMAIL
+    );
+    if (existingMember) {
+      await adminContext.request.post('/api/rest/organizations/remove-member', {
+        data: { memberIdOrEmail: INVITED_EMAIL },
+      });
+    }
+
+    // 4. Create a new invitation
+    await adminContext.request.post('/api/rest/organizations/invite', {
+      data: { email: INVITED_EMAIL, role: 'member' },
+    });
+
+    // 5. Get the new invitation ID
+    const orgResp2 = await adminContext.request.get(
+      '/api/rest/organizations/active'
+    );
+    const org2 = await orgResp2.json();
+    const invitation = (org2.invitations as Invitation[] | undefined)?.find(
+      (i) => i.email === INVITED_EMAIL
+    );
+
+    if (!invitation?.id) {
+      throw new Error(
+        `Failed to find invitation for ${INVITED_EMAIL} after creation`
+      );
+    }
+
+    return invitation.id;
+  } finally {
+    await adminContext.close();
+  }
+}
+
+test.describe('Invitation flow', () => {
+  // The invited user is already authenticated via INVITED_FILE storage state.
+  // Visiting /invitations/<id> while authenticated triggers the auto-accept
+  // directly, avoiding the redirect-after-login flow.
+  test.use({ storageState: INVITED_FILE });
+
+  test('Accept an organization invitation', async ({
+    browser,
+    page,
+    invitationPage,
+  }) => {
+    const invitationId = await ensureInvitation(browser);
+
+    await page.goto(`/invitations/${invitationId}`);
+
+    // The page auto-accepts once the session is available
+    await invitationPage.expectAccepted();
+
+    // Navigate to the app
+    await invitationPage.goToApp();
+    await page.waitForURL(/\/app\//);
+    await expect(page.getByTestId('layout-app')).toBeVisible();
+  });
+});

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -4,6 +4,7 @@ export { CommuteFormPage } from './commute-form.page';
 export { CommuteTemplatesPage } from './commute-templates.page';
 export { ConfirmDialog } from './confirm-dialog.page';
 export { DashboardPage } from './dashboard.page';
+export { InvitationPage } from './invitation.page';
 export { LoginPage } from './login.page';
 export { LocationsPage } from './locations.page';
 export { ManagerUsersPage } from './manager-users.page';

--- a/e2e/pages/invitation.page.ts
+++ b/e2e/pages/invitation.page.ts
@@ -1,0 +1,16 @@
+import { expect, type Page } from '@playwright/test';
+
+export class InvitationPage {
+  constructor(private readonly page: Page) {}
+
+  async expectAccepted() {
+    // Session load + acceptInvitation + setActive can take several seconds
+    await expect(
+      this.page.getByText('Invitation accepted').first()
+    ).toBeVisible({ timeout: 20_000 });
+  }
+
+  async goToApp() {
+    await this.page.getByRole('button', { name: 'Go to app' }).click();
+  }
+}

--- a/e2e/setup/auth.setup.ts
+++ b/e2e/setup/auth.setup.ts
@@ -3,6 +3,8 @@ import { test as setup } from 'e2e/utils';
 import {
   ADMIN_EMAIL,
   ADMIN_FILE,
+  INVITED_EMAIL,
+  INVITED_FILE,
   USER_EMAIL,
   USER_FILE,
 } from 'e2e/utils/constants';
@@ -29,4 +31,27 @@ setup('authenticate as user', async ({ page }) => {
   await expect(page.getByTestId('layout-app')).toBeVisible();
 
   await page.context().storageState({ path: USER_FILE });
+});
+
+setup('authenticate as invited user', async ({ page }) => {
+  await page.to('/login');
+  await page.login({ email: INVITED_EMAIL });
+
+  await page.waitForURL('/app');
+
+  // New users land on an onboarding screen inside the app route (no onboardedAt).
+  // Complete it so the saved storage state reflects a fully onboarded user.
+  try {
+    await page
+      .getByRole('heading', { name: 'Welcome' })
+      .waitFor({ state: 'visible', timeout: 5000 });
+    await page.getByRole('textbox').first().fill('Invited User');
+    await page.getByRole('button', { name: 'Continue' }).click();
+  } catch {
+    // Already onboarded on a subsequent run — nothing to do.
+  }
+
+  await expect(page.getByTestId('layout-app')).toBeVisible();
+
+  await page.context().storageState({ path: INVITED_FILE });
 });

--- a/e2e/utils/constants.ts
+++ b/e2e/utils/constants.ts
@@ -7,3 +7,6 @@ export const ADMIN_FILE = `${AUTH_FILE_BASE}/admin.json`;
 export const ADMIN_EMAIL = 'admin@admin.com';
 
 export const ORG_SLUG = 'default';
+
+export const INVITED_EMAIL = 'invited@user.com';
+export const INVITED_FILE = `${AUTH_FILE_BASE}/invited.json`;

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -6,6 +6,7 @@ import {
   CommuteTemplatesPage,
   ConfirmDialog,
   DashboardPage,
+  InvitationPage,
   LoginPage,
   LocationsPage,
   ManagerUsersPage,
@@ -21,6 +22,7 @@ type PageFixtures = {
   confirmDialog: ConfirmDialog;
   commuteFormPage: CommuteFormPage;
   commuteTemplatesPage: CommuteTemplatesPage;
+  invitationPage: InvitationPage;
   locationsPage: LocationsPage;
   usersPage: ManagerUsersPage;
   requestsPage: RequestsPage;
@@ -51,6 +53,9 @@ const test = testWithPage.extend<PageFixtures>({
   },
   commuteTemplatesPage: async ({ page }, use) => {
     await use(new CommuteTemplatesPage(page));
+  },
+  invitationPage: async ({ page }, use) => {
+    await use(new InvitationPage(page));
   },
   locationsPage: async ({ page }, use) => {
     await use(new LocationsPage(page));

--- a/src/features/organization/page-accept-invitation.tsx
+++ b/src/features/organization/page-accept-invitation.tsx
@@ -20,7 +20,7 @@ export const PageAcceptInvitation = ({
 
   const hasMutatedRef = useRef(false);
 
-  const { mutate, isPending, isIdle, isError } = useMutation({
+  const { mutate, isPending, isIdle, isError, isSuccess } = useMutation({
     mutationFn: async () => {
       const result = await authClient.organization.acceptInvitation({
         invitationId,
@@ -57,13 +57,18 @@ export const PageAcceptInvitation = ({
     return null;
   }
 
-  if (isPending || isIdle || session.isPending) {
+  // Show success as soon as the mutation completes, regardless of any
+  // subsequent session re-fetch triggered by setActive().
+  if (isSuccess) {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-4">
-        <Spinner className="opacity-60" />
-        <p className="text-sm text-neutral-500">
-          {t('organization:invitation.accepting')}
-        </p>
+        <CheckCircleIcon className="text-green-500 size-12" />
+        <h1 className="text-lg font-semibold">
+          {t('organization:invitation.accepted')}
+        </h1>
+        <Button onClick={() => navigate({ to: '/app' })}>
+          {t('organization:invitation.backToApp')}
+        </Button>
       </div>
     );
   }
@@ -85,15 +90,14 @@ export const PageAcceptInvitation = ({
     );
   }
 
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4">
-      <CheckCircleIcon className="text-green-500 size-12" />
-      <h1 className="text-lg font-semibold">
-        {t('organization:invitation.accepted')}
-      </h1>
-      <Button onClick={() => navigate({ to: '/app' })}>
-        {t('organization:invitation.backToApp')}
-      </Button>
-    </div>
-  );
+  if (isPending || isIdle || session.isPending) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4">
+        <Spinner className="opacity-60" />
+        <p className="text-sm text-neutral-500">
+          {t('organization:invitation.accepting')}
+        </p>
+      </div>
+    );
+  }
 };


### PR DESCRIPTION
Closes #130

## Summary

- Add `InvitationPage` page object (`expectAccepted`, `goToApp`)
- Add `INVITED_EMAIL` / `INVITED_FILE` constants and an `authenticate as invited user` setup step that handles onboarding for new accounts on first run
- Add `e2e/invitations.spec.ts` covering scenario 11.1 (accept an org invitation)
- Fix `page-accept-invitation.tsx`: `setActive()` triggers an internal Better Auth session re-fetch which was setting `session.isPending = true` again, permanently blocking the success UI. Moving the `isSuccess` check before `session.isPending` ensures the success state renders as soon as the mutation completes.

## Test plan

- [x] Run `pnpm test:e2e` — setup creates `invited@user.com` account (onboarding auto-completed), invitation spec passes
- [x] Run a second time — setup skips onboarding (already onboarded), spec still passes with the idempotent `ensureInvitation` helper