### PR TITLE
fix: prevent driver from opening booking drawer for own commute

### DIFF
--- a/e2e/booking.spec.ts
+++ b/e2e/booking.spec.ts
@@ -1,5 +1,76 @@
+import dayjs from 'dayjs';
+
 import { expect, test } from 'e2e/utils';
-import { USER_FILE } from 'e2e/utils/constants';
+import { ADMIN_FILE, ORG_SLUG, USER_FILE } from 'e2e/utils/constants';
+
+test.describe('[REGRESSION] Driver cannot open booking drawer for their own commute', () => {
+  test.use({ storageState: ADMIN_FILE });
+
+  test('booking drawer does not open via URL params for driver own commute', async ({
+    page,
+    commuteFormPage,
+  }) => {
+    // Create a commute as admin (driver) so we have one with known stop IDs
+    const createResponsePromise = page.waitForResponse(
+      (r) => r.url().includes('/api/rpc/commute/create') && r.status() === 200
+    );
+
+    await commuteFormPage.goto();
+    await commuteFormPage.fromScratchButton.click();
+
+    // Use a date within the dashboard's 7-day range so getByDate returns it
+    const futureDate = dayjs().add(3, 'day').format('DD/MM/YYYY');
+    await commuteFormPage.dateInput.fill(futureDate);
+    await commuteFormPage.dateInput.blur();
+
+    const roundTrip = commuteFormPage.roundTripCheckbox;
+    if (await roundTrip.isChecked()) {
+      await roundTrip.click();
+    }
+
+    await commuteFormPage.seatsInput.clear();
+    await commuteFormPage.seatsInput.fill('2');
+    await commuteFormPage.clickNext();
+
+    // Outward stops
+    await commuteFormPage.selectLocation(0, 'Home');
+    await commuteFormPage.fillOutwardTime(0, '08:00');
+    await commuteFormPage.selectLocation(1, 'Office');
+    await commuteFormPage.fillOutwardTime(1, '08:30');
+    await commuteFormPage.clickNext();
+
+    // Recap & create
+    await commuteFormPage.clickCreate();
+
+    // Extract stop ID from the creation response
+    const createResponse = await createResponsePromise;
+    const createBody = await createResponse.json();
+    const createdCommute: { id: string; stops: Array<{ id: string }> } =
+      createBody?.json ?? createBody;
+
+    const stopId = createdCommute.stops[0]?.id;
+    const commuteId = createdCommute.id;
+    expect(stopId).toBeTruthy();
+
+    // Navigate to the dashboard with URL params that would open the booking drawer
+    await page.goto(
+      `/app/${ORG_SLUG}/?bookingStop=${stopId}&openCommutes=${commuteId}`
+    );
+
+    // Wait for the dashboard to fully load (commute cards render after data fetch)
+    await expect(
+      page.locator('[data-slot="card-commute"]').first()
+    ).toBeVisible({ timeout: 10_000 });
+
+    // The booking drawer must NOT open for the driver's own commute
+    await expect(
+      page.getByRole('dialog', { name: 'Book a ride' })
+    ).not.toBeVisible();
+
+    // The bookingStop search param should be cleared from the URL
+    await expect(page).not.toHaveURL(/bookingStop=/);
+  });
+});
 
 test.describe.serial('Booking flow', () => {
   test.use({ storageState: USER_FILE });

--- a/e2e/invitations.spec.ts
+++ b/e2e/invitations.spec.ts
@@ -88,9 +88,27 @@ test.describe('Invitation flow', () => {
     // The page auto-accepts once the session is available
     await invitationPage.expectAccepted();
 
-    // Navigate to the app
+    // Navigate to the app — the "Go to app" button calls navigate({ to: '/app' }).
+    // Depending on parallel test interference the user may need onboarding or may
+    // land on a "no organization" page, so we handle several outcomes.
     await invitationPage.goToApp();
-    await page.waitForURL(/\/app\//);
-    await expect(page.getByTestId('layout-app')).toBeVisible();
+
+    // Wait for the page to settle after the client-side navigation.
+    await page.waitForLoadState('networkidle');
+
+    // Happy path: user is onboarded and has an org → OrgRedirect fires → layout-app.
+    // Onboarding path: user was re-created without onboardedAt → "Welcome" heading.
+    const layoutApp = page.getByTestId('layout-app');
+    const onboardingHeading = page.getByRole('heading', { name: 'Welcome' });
+
+    await expect(layoutApp.or(onboardingHeading)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    if (await onboardingHeading.isVisible().catch(() => false)) {
+      await page.getByRole('textbox').first().fill('Invited User');
+      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(layoutApp).toBeVisible({ timeout: 15_000 });
+    }
   });
 });

--- a/e2e/pages/dashboard.page.ts
+++ b/e2e/pages/dashboard.page.ts
@@ -12,9 +12,11 @@ export class DashboardPage {
 
   async expandCard(card: Locator) {
     await card.locator('[data-slot="card-commute-trigger"]').click();
-    await expect(
-      card.locator('[data-slot="card-commute-content"]')
-    ).toBeVisible();
+    const content = card.locator('[data-slot="card-commute-content"]');
+    await expect(content).toBeVisible();
+    // Wait for the collapsible open animation to finish so that child
+    // buttons are no longer intercepted by overlapping elements.
+    await expect(content).not.toHaveAttribute('data-starting-style', /.*/);
   }
 
   cardContent(card: Locator) {

--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -1,6 +1,7 @@
 import { getUiState } from '@bearstudio/ui-state';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
+import { useEffect } from 'react';
 import { PlusIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -81,6 +82,14 @@ export const PageDashboard = () => {
         }));
       })
       .find((s) => s.stopId === bookingStopId) ?? null;
+
+  const isDriverBooking = bookingInfo?.driver?.id === currentUserId;
+
+  useEffect(() => {
+    if (isDriverBooking) {
+      setSearchParams({ bookingStop: null });
+    }
+  }, [isDriverBooking, setSearchParams]);
 
   const commuteCancel = useMutation(
     orpc.commute.cancel.mutationOptions({
@@ -233,7 +242,7 @@ export const PageDashboard = () => {
           driver={bookingInfo?.driver ?? null}
           isFirstStop={bookingInfo?.isFirstStop ?? false}
           isLastStop={bookingInfo?.isLastStop ?? false}
-          open={bookingInfo !== null}
+          open={bookingInfo !== null && !!currentUserId && !isDriverBooking}
           onOpenChange={(open) => {
             if (!open) setSearchParams({ bookingStop: null });
           }}


### PR DESCRIPTION
## Summary
- Closes #118
- A driver can no longer open the booking drawer for their own commute — neither via UI interaction nor by crafting URL search params (`?bookingStop=...&openCommutes=...`)
- The `bookingStop` search param is automatically cleared from the URL when the driver is detected
- The drawer open state is gated on session being loaded to prevent a race condition where the drawer briefly opens before the user ID is available

## Test plan
- [x] Add `[REGRESSION]` e2e test: creates a commute as admin, navigates to dashboard with booking URL params for own commute, asserts drawer does NOT open and URL params are cleared
- [x] Fix invitation e2e test resilience to parallel test interference (handles onboarding when user is deleted/re-created by parallel tests)
- [x] Fix collapsible card animation interception in dashboard page object (`expandCard` now waits for Base UI animation to complete)