### PR TITLE
fix: prevent driver from booking seats on their own commute

### DIFF
--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -1,8 +1,8 @@
 import { getUiState } from '@bearstudio/ui-state';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
-import { useEffect } from 'react';
 import { PlusIcon } from 'lucide-react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import '@/lib/dayjs/config';

--- a/src/server/routers/booking.ts
+++ b/src/server/routers/booking.ts
@@ -39,6 +39,12 @@ export default {
         throw new ORPCError('NOT_FOUND');
       }
 
+      if (stop.commute.driverMemberId === context.memberId) {
+        throw new ORPCError('FORBIDDEN', {
+          message: 'Drivers cannot book seats on their own commutes',
+        });
+      }
+
       const orders = stop.commute.stops.map((s) => s.order);
       const isLastStop = stop.order === Math.max(...orders);
       const allowOutward = !isLastStop;

--- a/src/server/routers/booking.unit.test.ts
+++ b/src/server/routers/booking.unit.test.ts
@@ -220,6 +220,35 @@ describe('booking router', () => {
       });
     });
 
+    it('should throw FORBIDDEN when the driver tries to book their own commute', async () => {
+      mockDb.stop.findUnique.mockResolvedValue({
+        order: 1,
+        commuteId: 'commute-1',
+        commute: {
+          driverMemberId: mockMemberId,
+          type: 'ROUND',
+          seats: 4,
+          stops: [{ order: 0 }, { order: 1 }, { order: 2 }],
+          driver: {
+            organizationId: mockOrganizationId,
+            autoAccept: false,
+            notificationPreferences: [],
+            user: {
+              id: 'driver-user-1',
+              name: 'Driver',
+              email: 'driver@test.com',
+            },
+          },
+        },
+      });
+
+      await expect(
+        call(bookingRouter.request, requestInput)
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      });
+    });
+
     it('should throw CONFLICT when user already has a booking on this commute', async () => {
       mockDb.stop.findUnique.mockResolvedValue({
         order: 1,


### PR DESCRIPTION
## Summary

- Adds a server-side `FORBIDDEN` guard in `booking.request` to reject any attempt by a driver to book a seat on a commute they are driving
- Fixes the missing check identified in #119 — all other handlers (`accept`, `refuse`, `cancel`) already had proper ownership guards

## Test plan

- [x] Unit test added: `"should throw FORBIDDEN when the driver tries to book their own commute"`
- [x] All 38 booking unit tests pass

Closes #119