### PR TITLE
fix: sort imports in nav-sidebar

### DIFF
--- a/src/layout/manager/nav-sidebar.tsx
+++ b/src/layout/manager/nav-sidebar.tsx
@@ -13,6 +13,7 @@ import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Logo } from '@/components/brand/logo';
+import { ButtonLink } from '@/components/ui/button-link';
 import {
   Sidebar,
   SidebarContent,
@@ -32,7 +33,6 @@ import {
 import { WithPermissions } from '@/features/auth/with-permission';
 import { OrgSwitcher } from '@/features/organization/org-switcher';
 import { NavUser } from '@/layout/manager/nav-user';
-import { ButtonLink } from '@/components/ui/button-link';
 
 export const NavSidebar = (props: {
   children?: ReactNode;


### PR DESCRIPTION
## Summary
- Fix unsorted import in `nav-sidebar.tsx` that caused oxlint CI failure
- Move `ButtonLink` import to the correct position within `@/components/ui/` group

## Test plan
- [x] CI oxlint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)