### PR TITLE
feat: animate speed dial open/close with stagger and exit transitions

### DIFF
--- a/src/components/ui/floating-action-button.tsx
+++ b/src/components/ui/floating-action-button.tsx
@@ -7,18 +7,21 @@ import { useIsMobile } from '@/hooks/use-mobile';
 
 import { Button } from '@/components/ui/button';
 
-export const fabVariants = cva('rounded-full shadow-lg', {
-  variants: {
-    size: {
-      default: "size-16 [&_svg:not([class*='size-'])]:size-6",
-      sm: "size-14 [&_svg:not([class*='size-'])]:size-5",
-      lg: "size-18 [&_svg:not([class*='size-'])]:size-7",
+export const fabVariants = cva(
+  'rounded-full shadow-lg transition-[color,box-shadow,transform] active:scale-[0.97]',
+  {
+    variants: {
+      size: {
+        default: "size-16 [&_svg:not([class*='size-'])]:size-6",
+        sm: "size-14 [&_svg:not([class*='size-'])]:size-5",
+        lg: "size-18 [&_svg:not([class*='size-'])]:size-7",
+      },
     },
-  },
-  defaultVariants: {
-    size: 'default',
-  },
-});
+    defaultVariants: {
+      size: 'default',
+    },
+  }
+);
 
 export type FabVariantProps = VariantProps<typeof fabVariants>;
 

--- a/src/components/ui/speed-dial.tsx
+++ b/src/components/ui/speed-dial.tsx
@@ -1,12 +1,18 @@
-import { XIcon } from 'lucide-react';
-import { ComponentProps, ReactNode, useState } from 'react';
+import { Children, ComponentProps, ReactNode } from 'react';
 import { createPortal } from 'react-dom';
+
+import { cn } from '@/lib/tailwind/utils';
+import { useOpenWithExitAnimation } from '@/hooks/use-open-with-exit-animation';
+import { useStaggerAnimation } from '@/hooks/use-stagger-animation';
 
 import { Button } from '@/components/ui/button';
 import {
   type FabVariantProps,
   fabVariants,
 } from '@/components/ui/floating-action-button';
+
+// Max exit duration: last item delay (items × exitStagger) + animation duration (150ms) + margin
+const EXIT_DURATION_MS = 220;
 
 type SpeedDialProps = {
   icon: ReactNode;
@@ -23,38 +29,67 @@ export const SpeedDial = ({
   fabSize,
   children,
 }: SpeedDialProps) => {
-  const [open, setOpen] = useState(false);
+  const { status, toggle, isVisible } =
+    useOpenWithExitAnimation(EXIT_DURATION_MS);
+
+  const items = Children.toArray(children);
+  const stagger = useStaggerAnimation(items.length, status, {
+    enterClass: 'animate-speed-dial-item-in',
+    exitClass: 'animate-speed-dial-item-out',
+  });
 
   const fabRoot = document.getElementById('fab-portal-root');
 
   return (
     <>
-      {open &&
+      {isVisible &&
         createPortal(
           <div
-            className="fixed inset-0 z-20 bg-black/40"
-            onClick={() => setOpen(false)}
+            className={cn(
+              'fixed inset-0 z-20 bg-black/40 motion-reduce:animate-none',
+              status === 'closing'
+                ? 'animate-speed-dial-backdrop-out'
+                : 'animate-speed-dial-backdrop-in'
+            )}
+            onClick={toggle}
           />,
           document.body
         )}
       {fabRoot &&
         createPortal(
           <div className="flex flex-col items-end gap-3">
-            {open && (
-              <div
-                className="grid grid-cols-[1fr_auto] items-center gap-3"
-                onClick={() => setOpen(false)}
-              >
-                {children}
+            {isVisible && (
+              <div className="grid grid-cols-[1fr_auto] gap-3" onClick={toggle}>
+                {items.map((item, index) => (
+                  <div
+                    key={index}
+                    className={cn(
+                      'col-span-2 grid grid-cols-subgrid items-center motion-reduce:animate-none',
+                      stagger[index]?.animationClass
+                    )}
+                    style={{
+                      animationDelay: `${stagger[index]?.animationDelay ?? 0}ms`,
+                    }}
+                  >
+                    {item}
+                  </div>
+                ))}
               </div>
             )}
             <Button
               size="icon"
               variant={variant}
               className={fabVariants({ size: fabSize })}
-              onClick={() => setOpen((o) => !o)}
+              onClick={toggle}
             >
-              {open ? <XIcon /> : icon}
+              <span
+                className={cn(
+                  'transition-transform duration-200 ease-out motion-reduce:transition-none',
+                  status === 'open' ? 'rotate-45' : 'rotate-0'
+                )}
+              >
+                {icon}
+              </span>
               <span className="sr-only">{label}</span>
             </Button>
           </div>,
@@ -71,10 +106,10 @@ export const SpeedDialItem = ({
   label: ReactNode;
   children: ReactNode;
 }) => (
-  <div className="contents">
+  <>
     <span className="justify-self-end rounded-md bg-popover px-3 py-1.5 text-sm font-medium whitespace-nowrap text-popover-foreground shadow-md">
       {label}
     </span>
     {children}
-  </div>
+  </>
 );

--- a/src/hooks/use-open-with-exit-animation.ts
+++ b/src/hooks/use-open-with-exit-animation.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from 'react';
+
+export type OpenStatus = 'closed' | 'open' | 'closing';
+
+/**
+ * Manages an open/closing/closed state machine that keeps elements mounted
+ * during their exit animation before unmounting.
+ */
+export function useOpenWithExitAnimation(exitDuration = 220) {
+  const [status, setStatus] = useState<OpenStatus>('closed');
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const toggle = () => {
+    if (status === 'closed') {
+      setStatus('open');
+    } else {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setStatus('closing');
+      timerRef.current = setTimeout(() => setStatus('closed'), exitDuration);
+    }
+  };
+
+  return {
+    status,
+    toggle,
+    isVisible: status === 'open' || status === 'closing',
+  };
+}

--- a/src/hooks/use-stagger-animation.ts
+++ b/src/hooks/use-stagger-animation.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+
+import { type OpenStatus } from './use-open-with-exit-animation';
+
+type StaggerAnimationOptions = {
+  enterClass: string;
+  exitClass: string;
+  /** ms between each item on enter. Items appear bottom-to-top. Default: 50 */
+  enterStagger?: number;
+  /** ms between each item on exit. Items disappear top-to-bottom. Default: 20 */
+  exitStagger?: number;
+};
+
+/**
+ * Computes animation class and delay for each item in a staggered list,
+ * based on the current open/closing status.
+ *
+ * Enter: bottom-to-top (last item animates first, closest to the trigger).
+ * Exit:  top-to-bottom (first item animates first), faster than enter.
+ */
+export function useStaggerAnimation(
+  count: number,
+  status: OpenStatus,
+  options: StaggerAnimationOptions
+) {
+  const {
+    enterClass,
+    exitClass,
+    enterStagger = 50,
+    exitStagger = 20,
+  } = options;
+  const isClosing = status === 'closing';
+
+  return useMemo(
+    () =>
+      Array.from({ length: count }, (_, index) => ({
+        animationClass: isClosing ? exitClass : enterClass,
+        animationDelay: isClosing
+          ? index * exitStagger
+          : (count - 1 - index) * enterStagger,
+      })),
+    [count, isClosing, enterClass, exitClass, enterStagger, exitStagger]
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -87,6 +87,12 @@
   --container-5xs: 8rem; /* 128px */
   --container-4xs: 12rem; /* 192px */
   /* Tailwind --container-3xs: 16rem; (256px) */
+
+  /* Speed Dial */
+  --animate-speed-dial-item-in: speed-dial-item-in 200ms cubic-bezier(0.23, 1, 0.32, 1) both;
+  --animate-speed-dial-item-out: speed-dial-item-out 150ms cubic-bezier(0.23, 1, 0.32, 1) both;
+  --animate-speed-dial-backdrop-in: speed-dial-backdrop-in 200ms ease-out both;
+  --animate-speed-dial-backdrop-out: speed-dial-backdrop-out 200ms ease-out both;
 }
 
 :root {
@@ -332,6 +338,47 @@ html:active-view-transition-type(slide-right) {
 
   .animate-caret-blink {
     animation: caret-blink 1.25s ease-out infinite;
+  }
+}
+
+/* Speed Dial keyframes (registered via --animate-speed-dial-* in @theme) */
+@keyframes speed-dial-item-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes speed-dial-item-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(6px) scale(0.95);
+  }
+}
+
+@keyframes speed-dial-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes speed-dial-backdrop-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `useOpenWithExitAnimation` hook: state machine (closed → open → closing → closed) that keeps items mounted during exit animation
- Add `useStaggerAnimation` hook: computes per-item animation class and delay for staggered enter (bottom-to-top) and exit (top-to-bottom)
- Rework `SpeedDial` to use both hooks with CSS keyframe animations for items and backdrop; FAB icon rotates 45° when open
- Add press scale + transition to FAB via `fabVariants`
- Add `speed-dial-item-in/out` and `speed-dial-backdrop-in/out` keyframes in `app.css`

## Test plan

- [ ] Open speed dial: items animate in bottom-to-top with stagger
- [ ] Close speed dial (tap FAB or backdrop): items animate out top-to-bottom, backdrop fades out, then unmounts
- [ ] FAB icon rotates 45° on open, back to 0° on close
- [ ] FAB shows active press scale on tap
- [ ] `prefers-reduced-motion`: animations are skipped (`motion-reduce:animate-none`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)