### PR TITLE
feat: add hit-area utilities and apply to buttons for mobile tap targets

### DIFF
--- a/src/components/back-button.tsx
+++ b/src/components/back-button.tsx
@@ -18,6 +18,7 @@ export const BackButton = ({
     <ButtonLink
       variant="ghost"
       size="icon-sm"
+      className="hit-area-3"
       onClick={(e) => {
         if (canGoBack) {
           e.preventDefault();

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/tailwind/utils';
 import { Spinner } from '@/components/ui/spinner';
 
 const buttonVariants = cva(
-  "relative inline-flex w-fit max-w-full min-w-0 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border border-transparent text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-40 disabled:grayscale aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-40 data-disabled:grayscale dark:disabled:opacity-20 dark:aria-invalid:ring-destructive/40 dark:data-disabled:opacity-20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span]:gap-2",
+  "hit-area-2 relative inline-flex w-fit max-w-full min-w-0 shrink-0 cursor-pointer items-center justify-center rounded-md border border-transparent text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-40 disabled:grayscale aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-40 data-disabled:grayscale dark:disabled:opacity-20 dark:aria-invalid:ring-destructive/40 dark:data-disabled:opacity-20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span]:gap-2",
   {
     variants: {
       variant: {

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -48,7 +48,7 @@ function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
       className={cn(className)}
       {...props}
       render={
-        <InputGroupButton variant="ghost" size="icon-xs">
+        <InputGroupButton variant="ghost" size="icon-xs" className="hit-area-3">
           <XIcon className="pointer-events-none" />
         </InputGroupButton>
       }
@@ -86,7 +86,7 @@ function ComboboxInput({
             variant="ghost"
             render={<ComboboxPrimitive.Trigger />}
             data-slot="input-group-button"
-            className="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
+            className="hit-area-3 group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
             disabled={disabled}
           >
             <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -37,7 +37,11 @@ export const DatePicker = ({
             open={datePicker.isOpen}
             onOpenChange={(open) => datePicker.toggle(open)}
           >
-            <PopoverTrigger render={<InputGroupButton size="icon-xs" />}>
+            <PopoverTrigger
+              render={
+                <InputGroupButton size="icon-xs" className="hit-area-3" />
+              }
+            >
               <CalendarIcon />
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0" align="start">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -70,7 +70,7 @@ function DialogContent({
             render={
               <Button
                 variant="ghost"
-                className="absolute top-4 right-4"
+                className="hit-area-3 absolute top-4 right-4"
                 size="icon-sm"
               />
             }

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -20,6 +20,7 @@ export function PasswordInput({ ...props }: PasswordInputProps) {
         <InputGroupButton
           onClick={() => setVisible((v) => !v)}
           aria-label={visible ? 'Hide' : 'Show'}
+          className="hit-area-3"
         >
           {visible ? <EyeOffIcon /> : <EyeIcon />}
         </InputGroupButton>

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -93,7 +93,7 @@ export const SearchInput = ({
           onClick={handleClear}
           variant="ghost"
           size="icon-xs"
-          className="mr-0.5"
+          className="hit-area-3 mr-0.5"
         >
           <span className="sr-only">
             {clearLabel ?? t('components:searchInput.clear')}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -75,7 +75,7 @@ function SheetContent({
             render={
               <Button
                 variant="ghost"
-                className="absolute top-4 right-4"
+                className="hit-area-3 absolute top-4 right-4"
                 size="icon-sm"
               />
             }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,12 +1,12 @@
-@import 'tailwindcss';
-@import 'tw-animate-css';
+@import "tailwindcss";
+@import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme {
   --font-sans:
-    'Public Sans Variable', ui-sans-serif, system-ui, sans-serif,
-    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    "Public Sans Variable", ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --color-*: initial;
   --color-white: #fff;
   --color-black: #000;
@@ -313,13 +313,13 @@ html:active-view-transition-type(slide-right) {
       height: 100lvh; /* Force full height on iOS standalone */
     }
   }
-  input[type='time'] {
+  input[type="time"] {
     -webkit-appearance: none;
     appearance: none;
   }
-  input[type='time']::-webkit-calendar-picker-indicator,
-  input[type='time']::-webkit-inner-spin-button,
-  input[type='time']::-webkit-clear-button {
+  input[type="time"]::-webkit-calendar-picker-indicator,
+  input[type="time"]::-webkit-inner-spin-button,
+  input[type="time"]::-webkit-clear-button {
     display: none;
     -webkit-appearance: none;
   }
@@ -397,5 +397,150 @@ html:active-view-transition-type(slide-right) {
 
   .animate-float-in-space {
     animation: float-in-space 8s ease-in-out infinite;
+  }
+}
+
+@utility hit-area-debug {
+  position: relative;
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
+    @apply border border-dashed border-primary bg-primary/10;
+  }
+  &:hover::before {
+    @apply border border-dashed border-positive-500 bg-positive-500/10;
+  }
+}
+
+@utility hit-area {
+  position: relative;
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
+  }
+}
+
+@utility hit-area-* {
+  position: relative;
+  --hit-area-t: --spacing(--value(number) * -1);
+  --hit-area-t: calc(--value([*]) * -1);
+  --hit-area-b: --spacing(--value(number) * -1);
+  --hit-area-b: calc(--value([*]) * -1);
+  --hit-area-l: --spacing(--value(number) * -1);
+  --hit-area-l: calc(--value([*]) * -1);
+  --hit-area-r: --spacing(--value(number) * -1);
+  --hit-area-r: calc(--value([*]) * -1);
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
+  }
+}
+
+@utility hit-area-l-* {
+  position: relative;
+  --hit-area-l: --spacing(--value(number) * -1);
+  --hit-area-l: calc(--value([*]) * -1);
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
+  }
+}
+
+@utility hit-area-r-* {
+  position: relative;
+  --hit-area-r: --spacing(--value(number) * -1);
+  --hit-area-r: calc(--value([*]) * -1);
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
+  }
+}
+
+@utility hit-area-t-* {
+  position: relative;
+  --hit-area-t: --spacing(--value(number) * -1);
+  --hit-area-t: calc(--value([*]) * -1);
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
+  }
+}
+
+@utility hit-area-b-* {
+  position: relative;
+  --hit-area-b: --spacing(--value(number) * -1);
+  --hit-area-b: calc(--value([*]) * -1);
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
+  }
+}
+
+@utility hit-area-x-* {
+  position: relative;
+  --hit-area-l: --spacing(--value(number) * -1);
+  --hit-area-l: calc(--value([*]) * -1);
+  --hit-area-r: --spacing(--value(number) * -1);
+  --hit-area-r: calc(--value([*]) * -1);
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
+  }
+}
+
+@utility hit-area-y-* {
+  position: relative;
+  --hit-area-t: --spacing(--value(number) * -1);
+  --hit-area-t: calc(--value([*]) * -1);
+  --hit-area-b: --spacing(--value(number) * -1);
+  --hit-area-b: calc(--value([*]) * -1);
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-t, 0px);
+    right: var(--hit-area-r, 0px);
+    bottom: var(--hit-area-b, 0px);
+    left: var(--hit-area-l, 0px);
+    pointer-events: inherit;
   }
 }


### PR DESCRIPTION
## Summary

- Adds `hit-area-*` CSS utilities to `app.css` (all sides, per-axis, per-side variants + debug mode)
- Applies `hit-area-2` to all buttons via `buttonVariants` base class; also removes `overflow-hidden` from buttons since it clips the `::before` pseudo-element used by hit-area
- Applies `hit-area-3` to small icon buttons (back button, dialog/sheet close, combobox trigger/clear, date-picker trigger, search clear, password toggle)

## Test plan

- [ ] Tap targets on mobile feel larger on all buttons
- [ ] Small icon buttons (close, back, etc.) are noticeably easier to tap
- [ ] Loading spinner still renders correctly inside buttons (not clipped)
- [ ] No visual regressions from removing `overflow-hidden` on buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)