### PR TITLE
feat: add phone number format validation

### DIFF
--- a/src/features/account/schema.ts
+++ b/src/features/account/schema.ts
@@ -15,7 +15,7 @@ export type FormFieldsAccountUpdatePhone = z.infer<
 >;
 export const zFormFieldsAccountUpdatePhone = () =>
   z.object({
-    phone: zu.fieldText.nullish(),
+    phone: zu.fieldPhone.nullish(),
   });
 
 export type FormFieldsAccountUpdateImage = z.infer<

--- a/src/features/auth/schema.ts
+++ b/src/features/auth/schema.ts
@@ -38,5 +38,5 @@ export type FormFieldsOnboarding = z.infer<
 export const zFormFieldsOnboarding = () =>
   z.object({
     name: zu.fieldText.required(),
-    phone: zu.fieldText.nullish(),
+    phone: zu.fieldPhone.nullish(),
   });

--- a/src/lib/zod/zod-utils.ts
+++ b/src/lib/zod/zod-utils.ts
@@ -9,6 +9,13 @@ const emptyStringAsUndefined = (input: string) =>
   // Cast undefined value to string for React Hook Form inference
   input.trim() === '' ? (undefined as unknown as string) : input.trim();
 
+const isValidPhoneNumber = (val: string) => {
+  const digits = val.replace(/\D/g, '');
+  return (
+    /^[+\d][\d\s\-().]*$/.test(val) && digits.length >= 7 && digits.length <= 15
+  );
+};
+
 export const zu = {
   fieldText: {
     required: (
@@ -38,5 +45,25 @@ export const zu = {
         .transform(emptyStringAsUndefined)
         .optional()
         .pipe(z.string(params).optional()),
+  },
+  fieldPhone: {
+    nullish: (invalidMessage: string = t('common:errors.phoneInvalid')) =>
+      z
+        .string()
+        .transform(emptyStringAsNull)
+        .nullish()
+        .pipe(
+          z
+            .string()
+            .nullish()
+            .superRefine((val, ctx) => {
+              if (val != null && !isValidPhoneNumber(val)) {
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  message: invalidMessage,
+                });
+              }
+            })
+        ),
   },
 };

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -24,6 +24,7 @@
     "confirm": "Confirm"
   },
   "errors": {
-    "required": "Required"
+    "required": "Required",
+    "phoneInvalid": "Invalid phone number"
   }
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -24,6 +24,7 @@
     "confirm": "Confirmer"
   },
   "errors": {
-    "required": "Requis"
+    "required": "Requis",
+    "phoneInvalid": "Numéro de téléphone invalide"
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `zu.fieldPhone.nullish()` helper in `zod-utils.ts` that validates phone numbers broadly (7–15 digits, allows `+`, spaces, dashes, dots, parentheses)
- Applies the validation to the phone field in the account update form and the onboarding form
- Adds a `common:errors.phoneInvalid` i18n key (FR: "Numéro de téléphone invalide" / EN: "Invalid phone number")

## Test plan

- [ ] Enter an invalid value in the phone field (e.g. "abc", "123") → error message appears
- [ ] Enter a valid French number (`+33 6 12 34 56 78`, `0612345678`) → no error
- [ ] Enter a valid international number (`+1 (555) 123-4567`) → no error
- [ ] Leave the field empty → no error (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)