### PR TITLE
fix: show item name and icon in deletion confirmation dialogs

### DIFF
--- a/src/components/ui/confirm-responsive-drawer.tsx
+++ b/src/components/ui/confirm-responsive-drawer.tsx
@@ -1,3 +1,4 @@
+import { TriangleAlert } from 'lucide-react';
 import {
   cloneElement,
   ComponentProps,
@@ -35,6 +36,8 @@ export const ConfirmResponsiveDrawer = (props: {
   const [isPending, setIsPending] = useState(false);
   const [confirmationInput, setConfirmationInput] = useState('');
   const { close, open, isOpen } = useDisclosure();
+
+  const isDestructive = props.confirmVariant === 'destructive';
 
   const displayHeading =
     !props.title && !props.description
@@ -100,7 +103,12 @@ export const ConfirmResponsiveDrawer = (props: {
             }
           }}
         >
-          <ResponsiveDrawerHeader>
+          <ResponsiveDrawerHeader className="items-center text-center">
+            {isDestructive && (
+              <div className="mb-1 flex size-11 items-center justify-center self-center rounded-full bg-destructive/10">
+                <TriangleAlert className="size-5 text-destructive" />
+              </div>
+            )}
             <ResponsiveDrawerTitle>{displayHeading}</ResponsiveDrawerTitle>
             <ResponsiveDrawerDescription>
               {props.description}

--- a/src/features/commute-template/app/page-commute-templates.tsx
+++ b/src/features/commute-template/app/page-commute-templates.tsx
@@ -140,6 +140,7 @@ export const PageCommuteTemplates = ({ orgSlug }: { orgSlug: string }) => {
                       actions={
                         <div onClick={(e) => e.stopPropagation()}>
                           <ConfirmResponsiveDrawer
+                            title={item.name}
                             description={t(
                               'commuteTemplate:list.deleteConfirmDescription'
                             )}

--- a/src/features/location/app/page-locations.tsx
+++ b/src/features/location/app/page-locations.tsx
@@ -167,6 +167,7 @@ export const PageLocations = () => {
                   </DataListCell>
                   <DataListCell className="flex-none">
                     <ConfirmResponsiveDrawer
+                      title={item.name}
                       description={t('location:list.deleteConfirmDescription')}
                       confirmText={t('common:actions.delete')}
                       confirmVariant="destructive"


### PR DESCRIPTION
## Summary

- Passes `item.name` as `title` to `ConfirmResponsiveDrawer` in template and location deletion dialogs (fixes #163, fixes #164)
- Adds a centered `TriangleAlert` icon in a `bg-destructive/10` circle when `confirmVariant="destructive"`, giving immediate visual context for destructive actions
- Centers the header content for a cleaner, more balanced dialog layout

## Test plan

- [ ] Open the commute templates list, click the delete button on a template → dialog should show the template name and the warning icon
- [ ] Open the locations list, click the delete button on a location → dialog should show the location name and the warning icon
- [ ] Non-destructive confirmation dialogs (no `confirmVariant="destructive"`) should be unaffected — no icon shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)