### PR TITLE
FIX : Do not open keyboard when I add stop on mobile

### DIFF
--- a/src/features/commute/form-commute/step-outward-stops.tsx
+++ b/src/features/commute/form-commute/step-outward-stops.tsx
@@ -99,7 +99,9 @@ export const StepOutwardStops = ({
                 variant="ghost"
                 size="lg"
                 className="w-full border border-dashed"
-                onClick={() => insert(index + 1, defaultStop)}
+                onClick={() =>
+                  insert(index + 1, defaultStop, { shouldFocus: false })
+                }
               >
                 <PlusIcon className="size-3" />
                 {t(`${ns}:form.addStop`)}


### PR DESCRIPTION
close #153 

On ouvre plus le clavier lors de l'ajout d'un stop