### PR TITLE
fix(ci): only run PR title check on open and edit events

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ name: 🏷️ PR Title
 on:
   pull_request:
     branches: [dev, main]
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited]
 
 jobs:
   check-pr-title:


### PR DESCRIPTION
## Summary

- Remove `synchronize` and `reopened` from pr-title workflow triggers
- Title validation only needs to run when a PR is opened or its title is edited, not on every push

## Test plan

- [ ] Pushing to a PR no longer triggers the title check
- [ ] Opening or editing a PR title still triggers the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)