### PR TITLE
feat(commute): show template picker below details step

### DIFF
--- a/e2e/pages/commute-form.page.ts
+++ b/e2e/pages/commute-form.page.ts
@@ -19,6 +19,7 @@ export class CommuteFormPage {
   async selectTemplateFromDrawer(templateName: string) {
     await this.useTemplateButton.click();
     await this.page
+      .getByRole('dialog')
       .locator('[data-slot="card"]')
       .filter({ has: this.page.getByText(templateName) })
       .first()

--- a/src/features/commute/app/page-commute-new.tsx
+++ b/src/features/commute/app/page-commute-new.tsx
@@ -146,6 +146,22 @@ export const PageCommuteNew = ({
     })
   );
 
+  const handleSelectTemplate = ({
+    templateName,
+    ...data
+  }: { templateName: string } & Pick<
+    FormFieldsCommute,
+    'seats' | 'type' | 'comment' | 'stops'
+  >) => {
+    setSelectedTemplateName(templateName);
+    form.reset({
+      ...DEFAULT_VALUES,
+      date: search.date,
+      ...data,
+    });
+    toast.success(t('commute:templatePicker.templateApplied'));
+  };
+
   const handleSubmit = form.handleSubmit((values) => {
     commuteCreate.mutate({
       ...values,
@@ -212,6 +228,12 @@ export const PageCommuteNew = ({
                 }}
               >
                 <StepDetailsCommute />
+                <div className="-mx-4 mt-4 flex flex-col gap-2">
+                  <p className="px-4 text-sm font-medium text-muted-foreground">
+                    {t('commute:templatePicker.selectTemplate')}
+                  </p>
+                  <TemplatePicker onSelect={handleSelectTemplate} compact />
+                </div>
               </MultiStepFormStep>
               <MultiStepFormStep
                 name={t('commute:stepper.stops')}
@@ -311,15 +333,9 @@ export const PageCommuteNew = ({
           </ResponsiveDrawerHeader>
           <ResponsiveDrawerBody className="gap-3 overflow-hidden pb-6">
             <TemplatePicker
-              onSelect={({ templateName, ...data }) => {
-                setSelectedTemplateName(templateName);
-                form.reset({
-                  ...DEFAULT_VALUES,
-                  date: search.date,
-                  ...data,
-                });
+              onSelect={(data) => {
+                handleSelectTemplate(data);
                 setTemplatePickerOpen(false);
-                toast.success(t('commute:templatePicker.templateApplied'));
               }}
             />
           </ResponsiveDrawerBody>

--- a/src/features/commute/app/template-picker.tsx
+++ b/src/features/commute/app/template-picker.tsx
@@ -1,10 +1,12 @@
 import { getUiState } from '@bearstudio/ui-state';
 import { useQuery } from '@tanstack/react-query';
-import { PlusIcon } from 'lucide-react';
+import { ChevronRightIcon, PlusIcon } from 'lucide-react';
+import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { featureIcons } from '@/lib/feature-icons';
 import { orpc } from '@/lib/orpc/client';
+import { cn } from '@/lib/tailwind/utils';
 
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import {
@@ -28,8 +30,10 @@ type TemplateData = Pick<
 
 export const TemplatePicker = ({
   onSelect,
+  compact = false,
 }: {
   onSelect: (data: TemplateData) => void;
+  compact?: boolean;
 }) => {
   const { t } = useTranslation(['commute', 'commuteTemplate']);
   const templatesQuery = useQuery(
@@ -72,7 +76,7 @@ export const TemplatePicker = ({
           {[1, 0.75, 0.5].map((opacity) => (
             <Skeleton
               key={opacity}
-              className="h-40 w-64 shrink-0"
+              className={cn('w-64 shrink-0', compact ? 'h-20' : 'h-40')}
               style={{ opacity }}
             />
           ))}
@@ -106,7 +110,7 @@ export const TemplatePicker = ({
           {items.map((item) => (
             <Card
               key={item.id}
-              className="w-64 shrink-0 cursor-pointer"
+              className="group w-64 shrink-0 cursor-pointer"
               onClick={() => handleSelect(item)}
             >
               <CardHeader>
@@ -115,6 +119,9 @@ export const TemplatePicker = ({
                   type={item.type}
                   stopsCount={item.stops.length}
                   seats={item.seats}
+                  actions={
+                    <ChevronRightIcon className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                  }
                 />
               </CardHeader>
               <CardContent>
@@ -124,14 +131,27 @@ export const TemplatePicker = ({
                       {item.comment}
                     </p>
                   )}
-                  <CardCommuteStopsList
-                    stops={item.stops.map((stop) => ({
-                      ...stop,
-                      commuteId: '',
-                      passengers: [],
-                    }))}
-                    disableLinks
-                  />
+                  {compact ? (
+                    <p className="flex flex-wrap items-center gap-x-1 text-xs text-muted-foreground">
+                      {item.stops.map((stop, i) => (
+                        <Fragment key={stop.locationId}>
+                          {i > 0 && (
+                            <ChevronRightIcon className="size-3 shrink-0" />
+                          )}
+                          <span>{stop.location.name}</span>
+                        </Fragment>
+                      ))}
+                    </p>
+                  ) : (
+                    <CardCommuteStopsList
+                      stops={item.stops.map((stop) => ({
+                        ...stop,
+                        commuteId: '',
+                        passengers: [],
+                      }))}
+                      disableLinks
+                    />
+                  )}
                 </div>
               </CardContent>
             </Card>

--- a/src/locales/en/commute.json
+++ b/src/locales/en/commute.json
@@ -61,7 +61,8 @@
     "useTemplate": "Use a template",
     "usingTemplate": "Created from template \"{{name}}\"",
     "templateApplied": "Template applied",
-    "quickCreate": "Quick create from template \"{{name}}\""
+    "quickCreate": "Quick create from template \"{{name}}\"",
+    "selectTemplate": "Select a template"
   },
   "stepper": {
     "details": "Details",

--- a/src/locales/fr/commute.json
+++ b/src/locales/fr/commute.json
@@ -61,7 +61,8 @@
     "useTemplate": "Utiliser un modèle",
     "usingTemplate": "Créé à partir du modèle « {{name}} »",
     "templateApplied": "Modèle appliqué",
-    "quickCreate": "Création rapide depuis le modèle « {{name}} »"
+    "quickCreate": "Création rapide depuis le modèle « {{name}} »",
+    "selectTemplate": "Sélectionner un modèle"
   },
   "stepper": {
     "details": "Détails",


### PR DESCRIPTION
## Summary

- Adds a compact inline `TemplatePicker` directly below the Details step of the commute creation form
- Extracts `handleSelectTemplate` into a named function to avoid duplicated logic between the inline picker and the drawer
- Adds a `compact` prop to `TemplatePicker` with shorter skeleton cards and inline stop names separated by chevron icons
- Adds `selectTemplate` i18n key (EN + FR)

## Bug fix included

- Fixes missing `key` prop on React Fragment in `item.stops.map()` — shorthand `<>` cannot accept `key`; replaced with `<Fragment key={stop.locationId}>`

## Test plan

- [ ] Open the commute creation form and navigate to the Details step — template picker should appear below
- [ ] Select a template from the inline picker — form should populate and a success toast should show
- [ ] Open the drawer picker — same behaviour should apply
- [ ] Verify no React key warnings in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)