### PR TITLE
fix(notification): skip driver with no passengers instead of filtering by org

### DIFF
--- a/src/server/cron/daily-reminder.ts
+++ b/src/server/cron/daily-reminder.ts
@@ -145,8 +145,11 @@ function groupParticipantsByOrg(todayCommutes: RangeCommute[]) {
   for (const commute of todayCommutes) {
     const orgData = getOrCreateOrgData(orgDataByOrgId, commute.driver);
 
-    registerRecipient(orgData.recipients, commute.driver);
     const passengers = collectPassengers(commute, orgData.recipients);
+
+    if (passengers.length > 0) {
+      registerRecipient(orgData.recipients, commute.driver);
+    }
 
     orgData.commutes.push({
       date: commute.date,

--- a/src/server/cron/daily-reminder.ts
+++ b/src/server/cron/daily-reminder.ts
@@ -65,14 +65,6 @@ export async function sendDailyReminders(
   }
 
   const orgDataByOrgId = groupParticipantsByOrg(todayCommutes);
-  for (const [orgId, orgData] of orgDataByOrgId.entries()) {
-    const hasPassengerCommute = orgData.commutes.some(
-      (commute) => commute.passengers.length > 0
-    );
-    if (!hasPassengerCommute) {
-      orgDataByOrgId.delete(orgId);
-    }
-  }
 
   await notifyEachOrg(orgDataByOrgId, db, notifier, logger);
 
@@ -147,9 +139,9 @@ function groupParticipantsByOrg(todayCommutes: RangeCommute[]) {
 
     const passengers = collectPassengers(commute, orgData.recipients);
 
-    if (passengers.length > 0) {
-      registerRecipient(orgData.recipients, commute.driver);
-    }
+    if (passengers.length === 0) continue;
+
+    registerRecipient(orgData.recipients, commute.driver);
 
     orgData.commutes.push({
       date: commute.date,

--- a/src/server/notifications/channels/terminal.ts
+++ b/src/server/notifications/channels/terminal.ts
@@ -13,7 +13,7 @@ export const terminalChannel: NotificationChannel = {
     const [first] = recipients;
     const recipientLabel = first
       ? recipients.length > 1
-        ? `${recipients.length} recipients`
+        ? `${recipients.length} recipients (${recipients.map((r) => r.name).join(', ')})`
         : `${first.name} (${first.email})`
       : 'broadcast';
 


### PR DESCRIPTION
## Problème

Le fix de #288 ne fonctionnait pas complètement : les conducteurs sans passagers recevaient quand même un message avec `(passagers:)` vide.

## Pourquoi le fix précédent ne marchait pas

@Nikola-BS Le filtre que tu avais mis raisonnait au niveau de l'**organisation entière** :

```ts
const hasPassengerCommute = orgData.commutes.some(
  (commute) => commute.passengers.length > 0
);
if (!hasPassengerCommute) {
  orgDataByOrgId.delete(orgId);
}
```

Ça répond à la question : *"est-ce que cette org a au moins un trajet avec passagers ?"*. Si oui, l'org passe le filtre — et **tous** les conducteurs de l'org reçoivent un message, y compris ceux dont leur propre trajet est vide.

Cas concret : org avec conducteur A (a des passagers) et conducteur B (aucun passager). L'org passe le filtre grâce à A, mais B reçoit quand même `(passagers:)`.

## Fix

On enregistre un conducteur comme recipient **seulement si son propre trajet a des passagers**, au moment du `groupParticipantsByOrg`.

```ts
const passengers = collectPassengers(commute, orgData.recipients);

if (passengers.length > 0) {
  registerRecipient(orgData.recipients, commute.driver);
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)