### PR TITLE
fix(security): prevent IDOR in updateMemberRole and cancelInvitation

### DIFF
--- a/src/server/repositories/organization.repository.ts
+++ b/src/server/repositories/organization.repository.ts
@@ -36,11 +36,21 @@ export const createOrganizationRepository = (db: AppDB) => ({
     );
   },
 
-  updateMemberRole: (memberId: string, role: 'owner' | 'member') =>
+  updateMemberRole: (
+    memberId: string,
+    organizationId: string,
+    role: 'owner' | 'member'
+  ) =>
     db.member.update({
-      where: { id: memberId },
+      where: { id: memberId, organizationId },
       data: { role },
     }),
+
+  findMemberById: (memberId: string, organizationId: string) =>
+    db.member.findFirst({ where: { id: memberId, organizationId } }),
+
+  findInvitationById: (invitationId: string, organizationId: string) =>
+    db.invitation.findFirst({ where: { id: invitationId, organizationId } }),
 
   findByIdWithDetails: (id: string) =>
     db.organization.findUnique({

--- a/src/server/routers/organization.ts
+++ b/src/server/routers/organization.ts
@@ -349,14 +349,51 @@ export default {
     )
     .output(z.void())
     .handler(async ({ context, input }) => {
-      await context.organizations.updateMemberRole(input.memberId, input.role);
+      const membership = await context.organizations.findOwnerMembership(
+        context.user.id,
+        context.organizationId
+      );
+
+      if (!membership) {
+        throw new ORPCError('FORBIDDEN', {
+          message: 'Only org owners and admins can update member roles',
+        });
+      }
+
+      const targetMember = await context.organizations.findMemberById(
+        input.memberId,
+        context.organizationId
+      );
+
+      if (!targetMember) {
+        throw new ORPCError('NOT_FOUND', {
+          message: 'Member not found in this organization',
+        });
+      }
+
+      await context.organizations.updateMemberRole(
+        input.memberId,
+        context.organizationId,
+        input.role
+      );
     }),
 
   cancelInvitation: orgProcedure()
     .route({ method: 'POST', path: '/organizations/cancel-invitation', tags })
     .input(z.object({ invitationId: z.string() }))
     .output(z.void())
-    .handler(async ({ input }) => {
+    .handler(async ({ context, input }) => {
+      const invitation = await context.organizations.findInvitationById(
+        input.invitationId,
+        context.organizationId
+      );
+
+      if (!invitation) {
+        throw new ORPCError('NOT_FOUND', {
+          message: 'Invitation not found in this organization',
+        });
+      }
+
       await auth.api.cancelInvitation({
         headers: getRequestHeaders(),
         body: { invitationId: input.invitationId },

--- a/src/server/routers/organization.unit.spec.ts
+++ b/src/server/routers/organization.unit.spec.ts
@@ -1,0 +1,134 @@
+import { call } from '@orpc/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import organizationRouter from '@/server/routers/organization';
+import {
+  mockDb,
+  mockGetSession,
+  mockHasPermission,
+  mockMemberId,
+  mockOrganizationId,
+  mockUser,
+  mockUserHasPermission,
+} from '@/server/routers/test-utils';
+
+const { mockCancelInvitation } = vi.hoisted(() => ({
+  mockCancelInvitation: vi.fn(),
+}));
+
+vi.mock('@/server/auth', () => ({
+  auth: {
+    api: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+      userHasPermission: (...args: unknown[]) => mockUserHasPermission(...args),
+      hasPermission: (...args: unknown[]) => mockHasPermission(...args),
+      cancelInvitation: (...args: unknown[]) => mockCancelInvitation(...args),
+    },
+  },
+}));
+
+const defaultMember = {
+  id: mockMemberId,
+  userId: mockUser.id,
+  organizationId: mockOrganizationId,
+  role: 'member',
+};
+
+const ownerMembership = { ...defaultMember, role: 'owner' };
+
+const targetMember = {
+  id: 'target-member-1',
+  userId: 'other-user-1',
+  organizationId: mockOrganizationId,
+  role: 'member',
+};
+
+const mockInvitation = {
+  id: 'invitation-1',
+  organizationId: mockOrganizationId,
+  email: 'invited@example.com',
+  status: 'pending',
+};
+
+describe('organization router', () => {
+  describe('updateMemberRole', () => {
+    const input = { memberId: 'target-member-1', role: 'owner' as const };
+
+    // The organizationProcedure middleware calls db.member.findFirst once to verify
+    // org membership, then the handler calls it twice more (findOwnerMembership,
+    // findMemberById). mockResolvedValueOnce values are consumed in order, so we
+    // must account for the middleware call first.
+
+    it('should update role when caller is owner and member belongs to org', async () => {
+      mockDb.member.findFirst
+        .mockResolvedValueOnce(defaultMember) // middleware: org membership check
+        .mockResolvedValueOnce(ownerMembership) // handler: findOwnerMembership
+        .mockResolvedValueOnce(targetMember); // handler: findMemberById
+      mockDb.member.update.mockResolvedValue(undefined);
+
+      await expect(
+        call(organizationRouter.updateMemberRole, input)
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw FORBIDDEN when caller is not owner or admin', async () => {
+      mockDb.member.findFirst
+        .mockResolvedValueOnce(defaultMember) // middleware: org membership check
+        .mockResolvedValueOnce(null); // handler: findOwnerMembership → FORBIDDEN
+
+      await expect(
+        call(organizationRouter.updateMemberRole, input)
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('should throw NOT_FOUND when target member does not belong to org', async () => {
+      mockDb.member.findFirst
+        .mockResolvedValueOnce(defaultMember) // middleware: org membership check
+        .mockResolvedValueOnce(ownerMembership) // handler: findOwnerMembership
+        .mockResolvedValueOnce(null); // handler: findMemberById → NOT_FOUND
+
+      await expect(
+        call(organizationRouter.updateMemberRole, input)
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+
+    it('should throw UNAUTHORIZED when user is not authenticated', async () => {
+      mockGetSession.mockResolvedValue(null);
+
+      await expect(
+        call(organizationRouter.updateMemberRole, input)
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
+  });
+
+  describe('cancelInvitation', () => {
+    const input = { invitationId: 'invitation-1' };
+
+    it('should cancel invitation when it belongs to the active org', async () => {
+      mockDb.invitation.findFirst.mockResolvedValue(mockInvitation);
+      mockCancelInvitation.mockResolvedValue(undefined);
+
+      await expect(
+        call(organizationRouter.cancelInvitation, input)
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw NOT_FOUND when invitation does not belong to org', async () => {
+      mockDb.invitation.findFirst.mockResolvedValue(null);
+
+      await expect(
+        call(organizationRouter.cancelInvitation, input)
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      expect(mockCancelInvitation).not.toHaveBeenCalled();
+    });
+
+    it('should throw UNAUTHORIZED when user is not authenticated', async () => {
+      mockGetSession.mockResolvedValue(null);
+
+      await expect(
+        call(organizationRouter.cancelInvitation, input)
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #318 
- `updateMemberRole` accepted any `memberId` without verifying it belonged to the caller's organization — a user with `member.update` permission could escalate roles for members in other organizations, or elevate anyone to `owner`
- `cancelInvitation` accepted any `invitationId` without checking it belonged to the active organization — any authenticated user could cancel invitations from other orgs

## Fixes

- `updateMemberRole`: now verifies the caller is an owner/admin and that the target member belongs to `context.organizationId`
- `cancelInvitation`: now fetches the invitation and verifies it belongs to `context.organizationId` before cancelling
- `updateMemberRole` repository method now scopes the update to `organizationId` as a defense-in-depth measure

## Test plan

- [ ] updateMemberRole with a memberId from a different org returns NOT_FOUND
- [ ] updateMemberRole called by a non-owner/admin returns FORBIDDEN
- [ ] cancelInvitation with an invitationId from a different org returns NOT_FOUND
- [ ] Happy paths still work for legitimate owner/admin operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)