### PR TITLE
fix(security): prevent privilege escalation in updateMemberRole and cancelInvitation

### DIFF
--- a/src/server/routers/organization.ts
+++ b/src/server/routers/organization.ts
@@ -360,6 +360,12 @@ export default {
         });
       }
 
+      if (input.role === 'owner' && membership.role !== 'owner') {
+        throw new ORPCError('FORBIDDEN', {
+          message: 'Only org owners can assign the owner role',
+        });
+      }
+
       const targetMember = await context.organizations.findMemberById(
         input.memberId,
         context.organizationId
@@ -383,6 +389,17 @@ export default {
     .input(z.object({ invitationId: z.string() }))
     .output(z.void())
     .handler(async ({ context, input }) => {
+      const membership = await context.organizations.findOwnerMembership(
+        context.user.id,
+        context.organizationId
+      );
+
+      if (!membership) {
+        throw new ORPCError('FORBIDDEN', {
+          message: 'Only org owners and admins can cancel invitations',
+        });
+      }
+
       const invitation = await context.organizations.findInvitationById(
         input.invitationId,
         context.organizationId

--- a/src/server/routers/organization.unit.spec.ts
+++ b/src/server/routers/organization.unit.spec.ts
@@ -35,6 +35,7 @@ const defaultMember = {
 };
 
 const ownerMembership = { ...defaultMember, role: 'owner' };
+const adminMembership = { ...defaultMember, role: 'admin' };
 
 const targetMember = {
   id: 'target-member-1',
@@ -92,6 +93,34 @@ describe('organization router', () => {
       ).rejects.toMatchObject({ code: 'NOT_FOUND' });
     });
 
+    it('should throw FORBIDDEN when admin tries to assign owner role', async () => {
+      mockDb.member.findFirst
+        .mockResolvedValueOnce(defaultMember) // middleware: org membership check
+        .mockResolvedValueOnce(adminMembership); // handler: findOwnerMembership (throws before findMemberById)
+
+      await expect(
+        call(organizationRouter.updateMemberRole, {
+          memberId: 'target-member-1',
+          role: 'owner',
+        })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('should allow admin to assign member role', async () => {
+      mockDb.member.findFirst
+        .mockResolvedValueOnce(defaultMember) // middleware: org membership check
+        .mockResolvedValueOnce(adminMembership) // handler: findOwnerMembership (admin)
+        .mockResolvedValueOnce(targetMember); // handler: findMemberById
+      mockDb.member.update.mockResolvedValue(undefined);
+
+      await expect(
+        call(organizationRouter.updateMemberRole, {
+          memberId: 'target-member-1',
+          role: 'member',
+        })
+      ).resolves.toBeUndefined();
+    });
+
     it('should throw UNAUTHORIZED when user is not authenticated', async () => {
       mockGetSession.mockResolvedValue(null);
 
@@ -104,7 +133,10 @@ describe('organization router', () => {
   describe('cancelInvitation', () => {
     const input = { invitationId: 'invitation-1' };
 
-    it('should cancel invitation when it belongs to the active org', async () => {
+    it('should cancel invitation when caller is owner and invitation belongs to org', async () => {
+      mockDb.member.findFirst
+        .mockResolvedValueOnce(defaultMember) // middleware: org membership check
+        .mockResolvedValueOnce(ownerMembership); // handler: findOwnerMembership
       mockDb.invitation.findFirst.mockResolvedValue(mockInvitation);
       mockCancelInvitation.mockResolvedValue(undefined);
 
@@ -113,7 +145,22 @@ describe('organization router', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('should throw FORBIDDEN when caller is a regular member', async () => {
+      mockDb.member.findFirst
+        .mockResolvedValueOnce(defaultMember) // middleware: org membership check
+        .mockResolvedValueOnce(null); // handler: findOwnerMembership → FORBIDDEN
+
+      await expect(
+        call(organizationRouter.cancelInvitation, input)
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+      expect(mockCancelInvitation).not.toHaveBeenCalled();
+    });
+
     it('should throw NOT_FOUND when invitation does not belong to org', async () => {
+      mockDb.member.findFirst
+        .mockResolvedValueOnce(defaultMember) // middleware: org membership check
+        .mockResolvedValueOnce(ownerMembership); // handler: findOwnerMembership
       mockDb.invitation.findFirst.mockResolvedValue(null);
 
       await expect(


### PR DESCRIPTION
## Context

PR #324 fixed IDOR vulnerabilities in `updateMemberRole` and `cancelInvitation` (closes #318), but introduced two new privilege escalation issues in the process.

## Vulnerabilities fixed

### 1. Admin can assign the `owner` role (privilege escalation above own level)

`updateMemberRole` used `findOwnerMembership` to gate access, which accepts both `owner` and `admin` roles. However, the accepted `role` input includes `'owner'`, meaning an `admin` could call the endpoint and promote any member to `owner` — a role **above their own level**.

**Exploit scenario:** An `admin` calls `POST /organizations/update-member-role` with `{ memberId: <any member>, role: 'owner' }` and silently gains full ownership of the organization through a proxy account.

**Fix:** Added a check that requires `membership.role === 'owner'` when the requested role is `'owner'`. Admins can still assign `'member'` role (at or below their level), but only owners can grant ownership.

### 2. Any org member could cancel pending invitations

`cancelInvitation` had no authorization check on the caller's role — only on whether the invitation belonged to the org. Any authenticated member of the organization could cancel any pending invitation.

**Exploit scenario:** A malicious insider calls `POST /organizations/cancel-invitation` for each pending invitation ID, silently disrupting onboarding without the owner's knowledge.

**Fix:** Added a `findOwnerMembership` check before proceeding, requiring the caller to be an owner or admin.

## Test plan

- [x] `updateMemberRole`: admin calling with `role: 'owner'` returns `FORBIDDEN`
- [x] `updateMemberRole`: admin calling with `role: 'member'` still works
- [x] `cancelInvitation`: regular member gets `FORBIDDEN`
- [x] `cancelInvitation`: owner can still cancel an invitation
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)