### PR TITLE
fix(api): drop fresh-request workaround causing Vercel infinite loop

### DIFF
--- a/src/routes/api/auth.$.ts
+++ b/src/routes/api/auth.$.ts
@@ -5,28 +5,8 @@ import { auth } from '@/server/auth';
 export const Route = createFileRoute('/api/auth/$')({
   server: {
     handlers: {
-      GET: ({ request }) => {
-        return auth.handler(request);
-      },
-      POST: async ({ request }) => {
-        // The body of `request` is locked by the TanStack Start / Nitro
-        // adapter before it reaches us, so forwarding it directly leaves
-        // better-auth with an empty payload. We read it as text and rebuild
-        // a fresh Request.
-        //
-        // Drop this once `request` arrives with an unconsumed body — i.e.
-        // when `auth.handler(request)` directly returns a non-401 for a
-        // POST in an e2e run.
-        const body = await request.text();
-
-        return await auth.handler(
-          new Request(request.url, {
-            method: request.method,
-            headers: request.headers,
-            body,
-          })
-        );
-      },
+      GET: ({ request }) => auth.handler(request),
+      POST: ({ request }) => auth.handler(request),
     },
   },
 });

--- a/src/routes/api/rpc.$.ts
+++ b/src/routes/api/rpc.$.ts
@@ -11,32 +11,8 @@ const handler = new RPCHandler(router, {
 async function handle({ request }: { request: Request }) {
   const { response } = await handler.handle(request, {
     prefix: '/api/rpc',
-    context: {}, // Provide initial context if needed
+    context: {},
   });
-
-  return response ?? new Response('Not Found', { status: 404 });
-}
-
-async function handlePost({ request }: { request: Request }) {
-  // The body of `request` is locked by the TanStack Start / Nitro adapter
-  // before it reaches us, so forwarding it to oRPC leaves the procedure
-  // with an empty payload. We read it as text and rebuild a fresh Request.
-  //
-  // Drop this (and merge with `handle` again) once an oRPC mutation runs
-  // through `handle(request, ...)` directly without losing its input.
-  const body = await request.text();
-
-  const { response } = await handler.handle(
-    new Request(request.url, {
-      method: request.method,
-      headers: request.headers,
-      body,
-    }),
-    {
-      prefix: '/api/rpc',
-      context: {}, // Provide initial context if needed
-    }
-  );
 
   return response ?? new Response('Not Found', { status: 404 });
 }
@@ -45,7 +21,7 @@ export const Route = createFileRoute('/api/rpc/$')({
   server: {
     handlers: {
       GET: handle,
-      POST: handlePost,
+      POST: handle,
       PUT: handle,
       PATCH: handle,
       DELETE: handle,


### PR DESCRIPTION
## Summary

- Forward the original `Request` directly to oRPC (`/api/rpc/$`) and better-auth (`/api/auth/$`) handlers instead of rebuilding a fresh `Request` from `request.url` + headers + consumed body.
- The rebuilt `Request` was carrying Vercel internal routing headers (`x-vercel-id`, `x-forwarded-*`), which tripped Vercel's `infinite_loop_detected` on the dev environment.
- The original workaround was added to dodge a TanStack Start / Nitro adapter body-locking issue. The in-code comment said to drop it once the body arrives unconsumed — `@tanstack/react-start@1.167.65` (bumped in #332) appears to have fixed it.

## Test plan

- [ ] `pnpm dev` — log in via email OTP and confirm POST `/api/auth/sign-in/email-otp` returns a session (not 401 with empty payload).
- [ ] Trigger an oRPC mutation from the UI (e.g. create a commute) and confirm the procedure receives the input correctly (no empty payload).
- [ ] Deploy a Vercel preview and confirm `infinite_loop_detected` no longer fires on the auth + rpc routes.
- [ ] Run e2e suite locally (`pnpm test:e2e` or equivalent) to catch any regression on auth flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)