### PR TITLE
fix(vite): add JSON module fallback plugin to fix infinite app loading

### DIFF
--- a/src/lib/vite-plugins/json-module-fallback.ts
+++ b/src/lib/vite-plugins/json-module-fallback.ts
@@ -22,6 +22,9 @@ const toFilePath = (id: string) => {
 const isInsideDirectory = (filePath: string, directoryPath: string) =>
   filePath === directoryPath || filePath.startsWith(`${directoryPath}${sep}`);
 
+// Vite 8 no longer handles `?import` JSON requests in the dev server middleware,
+// causing the app to hang indefinitely waiting for a response. This plugin
+// intercepts those requests and serves JSON files from /src/ as ES modules.
 export function jsonModuleFallbackPlugin(): Plugin {
   const root = resolve('.');
   const srcDirectory = normalize(resolve(root, 'src'));

--- a/src/lib/vite-plugins/json-module-fallback.ts
+++ b/src/lib/vite-plugins/json-module-fallback.ts
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, normalize, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { type Plugin } from 'vite';
+
+const stripQuery = (id: string) => id.split('?')[0] ?? id;
+
+const toFilePath = (id: string) => {
+  const cleanId = stripQuery(id);
+  if (cleanId.startsWith('/@fs/')) {
+    return cleanId.slice('/@fs'.length);
+  }
+  if (cleanId.startsWith('file://')) {
+    return fileURLToPath(cleanId);
+  }
+  if (cleanId.startsWith('/src/')) {
+    return cleanId.slice(1);
+  }
+  return cleanId;
+};
+
+const isInsideDirectory = (filePath: string, directoryPath: string) =>
+  filePath === directoryPath || filePath.startsWith(`${directoryPath}${sep}`);
+
+export function jsonModuleFallbackPlugin(): Plugin {
+  const root = resolve('.');
+  const srcDirectory = normalize(resolve(root, 'src'));
+
+  const shouldHandle = (id: string) => {
+    const filePath = normalize(
+      isAbsolute(toFilePath(id))
+        ? toFilePath(id)
+        : resolve(root, toFilePath(id))
+    );
+
+    if (!filePath.endsWith('.json')) {
+      return false;
+    }
+
+    return isInsideDirectory(filePath, srcDirectory);
+  };
+
+  const loadJsonModule = async (id: string) => {
+    const filePath = normalize(
+      isAbsolute(toFilePath(id))
+        ? toFilePath(id)
+        : resolve(root, toFilePath(id))
+    );
+    const source = await readFile(filePath, 'utf8');
+    JSON.parse(source);
+
+    return {
+      code: `export default JSON.parse(${JSON.stringify(source)});\n`,
+      map: null,
+    };
+  };
+
+  return {
+    name: 'json-module-fallback',
+    enforce: 'pre',
+    configureServer(server) {
+      server.middlewares.use(async (request, response, next) => {
+        const url = request.url;
+
+        if (
+          !url?.startsWith('/src/') ||
+          !url.includes('?import') ||
+          !shouldHandle(url)
+        ) {
+          next();
+          return;
+        }
+
+        try {
+          const result = await loadJsonModule(url);
+          response.statusCode = 200;
+          response.setHeader('Content-Type', 'text/javascript');
+          response.setHeader('Cache-Control', 'no-cache');
+          response.end(result.code);
+        } catch (error) {
+          next(error);
+        }
+      });
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { nitro } from 'nitro/vite';
 import { defineConfig, loadEnv } from 'vite';
 import { qrcode } from 'vite-plugin-qrcode';
 
+import { jsonModuleFallbackPlugin } from './src/lib/vite-plugins/json-module-fallback';
 import { createPrismaCopyBinariesPlugin } from './src/lib/vite-plugins/prisma-copy-binaries';
 
 const { nitroRetrieveServerDirHook, prismaCopyBinariesPlugin } =
@@ -26,6 +27,7 @@ export default defineConfig(({ mode }) => {
       tailwindcss(),
       qrcode(),
       devtools(),
+      jsonModuleFallbackPlugin(),
       tanstackStart(),
       nitro({
         modules: [


### PR DESCRIPTION
## Summary

- Adds a `jsonModuleFallbackPlugin` Vite dev-server middleware that intercepts `/src/**/*.json?import` requests and serves them as ES modules (`export default JSON.parse(...)`)
- Fixes infinite app loading caused by Vite 8's changed JSON module handling
- Scoped to dev server only — no impact on builds

## Test plan

- [ ] Start the dev server and verify the app loads without infinite loading
- [ ] Confirm JSON imports from `/src/` resolve correctly in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)