### PR TITLE
fix(commute): handle trips that cross midnight

### DIFF
--- a/prisma/seed/commute.ts
+++ b/prisma/seed/commute.ts
@@ -14,47 +14,65 @@ function addDays(date: Date, days: number): Date {
   return d;
 }
 
-/** Generate ascending stop times for both outward and inward trips.
- *  Outward times are ascending (morning), inward times are also ascending
- *  (afternoon) and always start after the last outward arrival. */
+/** Shape of a generated trip on the day timeline:
+ *  - SAME_DAY:          outward in the morning, return the same afternoon.
+ *  - RETURN_NEXT_DAY:   outward in the morning, return early the *next* day.
+ *  - OVERNIGHT_OUTWARD: the outward leg itself crosses midnight, so its stops
+ *                       are spread over two days. */
+type TripShape = 'SAME_DAY' | 'RETURN_NEXT_DAY' | 'OVERNIGHT_OUTWARD';
+
+/** Generate stop times for both outward and inward trips.
+ *
+ *  Stops carry no date of their own — the app infers a day offset whenever a
+ *  time "wraps" before the previous one (see `isNextDay`). We exploit that to
+ *  produce multi-day commutes purely through the HH:mm values.
+ *
+ *  Outward times are ascending by index (the route runs stop 0 → last stop).
+ *  The return drives the reverse route, departing from the last stop, so inward
+ *  times are *descending* by index — the last stop has the earliest inward
+ *  time, stop 0 the latest. */
 function generateStopTimes(
   stopCount: number,
-  type: 'ROUND' | 'ONEWAY'
+  type: 'ROUND' | 'ONEWAY',
+  shape: TripShape = 'SAME_DAY'
 ): Array<{ outwardTime: string; inwardTime: string | null }> {
   const quarters = ['00', '15', '30', '45'] as const;
 
-  // Outward: pick a base hour then increment by 15min per stop
-  const outwardBaseHour = faker.number.int({ min: 6, max: 9 });
-  const outwardBaseQuarter = faker.number.int({ min: 0, max: 2 });
+  // Format a quarter-hour count (from midnight of the commute date) as HH:mm,
+  // wrapping past 24h so a leg crossing midnight yields a valid wall clock.
+  const fmt = (totalQuarters: number): string => {
+    const h = Math.floor(totalQuarters / 4) % 24;
+    const q = ((totalQuarters % 4) + 4) % 4;
+    return `${h.toString().padStart(2, '0')}:${quarters[q]}`;
+  };
 
-  // Last outward quarter (for the last stop)
-  const lastOutwardQuarter =
-    outwardBaseHour * 4 + outwardBaseQuarter + (stopCount - 1);
+  // Outward start (in quarter-hours). OVERNIGHT_OUTWARD anchors the LAST stop
+  // at 00:00 (next day) so the outward leg always crosses midnight, whatever
+  // the stop count.
+  const outwardStartQuarter =
+    shape === 'OVERNIGHT_OUTWARD'
+      ? 24 * 4 - (stopCount - 1)
+      : faker.number.int({ min: 6, max: 9 }) * 4 +
+        faker.number.int({ min: 0, max: 2 });
 
-  // Inward base starts at least 6 hours after the last outward time
-  const inwardBaseQuarter = lastOutwardQuarter + 6 * 4;
-  const inwardBaseHour = Math.floor(inwardBaseQuarter / 4);
-  const inwardBaseQ = inwardBaseQuarter % 4;
+  const lastOutwardQuarter = outwardStartQuarter + (stopCount - 1);
 
-  return Array.from({ length: stopCount }, (_, i) => {
-    // Outward times ascending: each stop is 15min later
-    const outTotalQuarters = outwardBaseHour * 4 + outwardBaseQuarter + i;
-    const outH = Math.floor(outTotalQuarters / 4);
-    const outQ = outTotalQuarters % 4;
+  // Inward time of the LAST stop (the return departs from there first).
+  // RETURN_NEXT_DAY pushes it to ~05:00–06:00 the following day, so its clock
+  // value sits before the last outward arrival and is read as the next day.
+  const inwardBaseQuarter =
+    shape === 'RETURN_NEXT_DAY'
+      ? 24 * 4 + faker.number.int({ min: 5 * 4, max: 6 * 4 })
+      : lastOutwardQuarter + 6 * 4;
 
-    // Inward times ascending: each stop is 15min later (same order as outward)
-    const inTotalQuarters = inwardBaseHour * 4 + inwardBaseQ + i;
-    const inH = Math.floor(inTotalQuarters / 4);
-    const inQ = inTotalQuarters % 4;
-
-    return {
-      outwardTime: `${outH.toString().padStart(2, '0')}:${quarters[outQ]}`,
-      inwardTime:
-        type === 'ROUND'
-          ? `${inH.toString().padStart(2, '0')}:${quarters[inQ]}`
-          : null,
-    };
-  });
+  return Array.from({ length: stopCount }, (_, i) => ({
+    // Outward ascending by index: each stop is 15min later.
+    outwardTime: fmt(outwardStartQuarter + i),
+    // Inward descending by index: the last stop leaves first, each
+    // earlier-indexed stop is 15min later.
+    inwardTime:
+      type === 'ROUND' ? fmt(inwardBaseQuarter + (stopCount - 1 - i)) : null,
+  }));
 }
 
 export async function createCommutes(organizationId: string) {
@@ -73,7 +91,8 @@ export async function createCommutes(organizationId: string) {
   });
 
   const today = getToday();
-  const COMMUTE_DAYS = 2;
+  // Spread commutes over a week so the dashboard shows trips on several days.
+  const COMMUTE_DAYS = 7;
 
   // Pre-fetch locations and existing commutes for all members in parallel
   const memberData = await Promise.all(
@@ -123,8 +142,23 @@ export async function createCommutes(organizationId: string) {
       // Create all commutes for all day offsets in parallel
       const dayResults = await Promise.all(
         Array.from({ length: COMMUTE_DAYS }, async (_, dayOffset) => {
-          const type = faker.helpers.arrayElement(['ROUND', 'ONEWAY'] as const);
-          const stopTimes = generateStopTimes(locations.length, type);
+          // Day 1 is a "return next day" round trip and day 2 an overnight
+          // outward leg (stops spread over two days), so every driver exercises
+          // both multi-day cases. Day 0 stays a same-day trip (it carries the
+          // seeded passenger booking) and the rest are random same-day trips.
+          let shape: TripShape;
+          let type: 'ROUND' | 'ONEWAY';
+          if (dayOffset === 1) {
+            shape = 'RETURN_NEXT_DAY';
+            type = 'ROUND';
+          } else if (dayOffset === 2) {
+            shape = 'OVERNIGHT_OUTWARD';
+            type = 'ROUND';
+          } else {
+            shape = 'SAME_DAY';
+            type = faker.helpers.arrayElement(['ROUND', 'ONEWAY'] as const);
+          }
+          const stopTimes = generateStopTimes(locations.length, type, shape);
 
           const commute = await db.commute.create({
             data: {

--- a/src/components/confirm-summary.tsx
+++ b/src/components/confirm-summary.tsx
@@ -19,6 +19,13 @@ type ConfirmSummaryProps = {
   dateFormat?: DateFormatKey;
   typeLabel: string;
   stops: StopForTimeline[];
+  /**
+   * Full ordered trip, used **only** to compute the per-stop day offsets when
+   * `stops` is a subset (e.g. the booking drawer renders a single boarding
+   * stop). A stop's day depends on the legs before it, so the offsets must be
+   * computed over the whole trip. Rendered stops are matched into it by reference.
+   */
+  tripStops?: StopForTimeline[];
 };
 
 export const ConfirmSummary = ({
@@ -27,9 +34,22 @@ export const ConfirmSummary = ({
   dateFormat = 'commute:dayHeader',
   typeLabel,
   stops,
+  tripStops,
 }: ConfirmSummaryProps) => {
   const { t } = useTranslation(['common']);
-  const dayLabels = computeStopDayLabels(stops, date, t('common:nextDay'));
+  const offsetStops = tripStops ?? stops;
+  const dayLabels = computeStopDayLabels(
+    offsetStops,
+    date,
+    t('common:nextDay')
+  );
+  // Each rendered stop reuses the label computed for its position in the full
+  // trip. When `tripStops` is omitted, `offsetStops === stops` so this is the
+  // identity mapping.
+  const labelFor = (stop: StopForTimeline) => {
+    const index = offsetStops.indexOf(stop);
+    return index >= 0 ? dayLabels[index] : undefined;
+  };
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border bg-muted/40 p-3 text-left text-sm">
@@ -62,7 +82,7 @@ export const ConfirmSummary = ({
             {stops.map((stop, i) => (
               <StopsTimelineItem
                 key={stop.location.id}
-                stop={{ ...stop, ...dayLabels[i] }}
+                stop={{ ...stop, ...labelFor(stop) }}
                 isFirst={i === 0}
                 isLast={i === stops.length - 1}
               />

--- a/src/components/confirm-summary.tsx
+++ b/src/components/confirm-summary.tsx
@@ -38,10 +38,8 @@ export const ConfirmSummary = ({
 }: ConfirmSummaryProps) => {
   const { t } = useTranslation(['common']);
   const offsetStops = tripStops ?? stops;
-  const dayLabels = computeStopDayLabels(
-    offsetStops,
-    date,
-    t('common:nextDay')
+  const dayLabels = computeStopDayLabels(offsetStops, (offset) =>
+    t('common:dayBadge', { count: offset })
   );
   // Each rendered stop reuses the label computed for its position in the full
   // trip. When `tripStops` is omitted, `offsetStops === stops` so this is the

--- a/src/components/confirm-summary.tsx
+++ b/src/components/confirm-summary.tsx
@@ -42,12 +42,14 @@ export const ConfirmSummary = ({
     t('common:dayBadge', { count: offset })
   );
   // Each rendered stop reuses the label computed for its position in the full
-  // trip. When `tripStops` is omitted, `offsetStops === stops` so this is the
-  // identity mapping.
-  const labelFor = (stop: StopForTimeline) => {
-    const index = offsetStops.indexOf(stop);
-    return index >= 0 ? dayLabels[index] : undefined;
-  };
+  // trip. We match on `location.id` (unique within a trip, and already the
+  // render key below) rather than object identity, so a cloned/normalised stop
+  // still resolves its label instead of silently losing its day badge.
+  const labelByLocationId = new Map(
+    offsetStops.map((stop, i) => [stop.location.id, dayLabels[i]])
+  );
+  const labelFor = (stop: StopForTimeline) =>
+    labelByLocationId.get(stop.location.id);
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border bg-muted/40 p-3 text-left text-sm">

--- a/src/components/confirm-summary.tsx
+++ b/src/components/confirm-summary.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { useTranslation } from 'react-i18next';
 import '@/lib/dayjs/config';
 
 import { type DateFormatKey } from '@/lib/dayjs/formats';
@@ -10,6 +11,7 @@ import {
   type StopForTimeline,
   StopsTimelineItem,
 } from '@/features/commute/stops-timeline';
+import { computeStopDayLabels } from '@/features/commute/time-utils';
 
 type ConfirmSummaryProps = {
   user?: { name?: string | null; image?: string | null };
@@ -26,6 +28,9 @@ export const ConfirmSummary = ({
   typeLabel,
   stops,
 }: ConfirmSummaryProps) => {
+  const { t } = useTranslation(['common']);
+  const dayLabels = computeStopDayLabels(stops, date, t('common:nextDay'));
+
   return (
     <div className="flex flex-col gap-3 rounded-lg border bg-muted/40 p-3 text-left text-sm">
       <div className="flex items-center gap-3">
@@ -57,7 +62,7 @@ export const ConfirmSummary = ({
             {stops.map((stop, i) => (
               <StopsTimelineItem
                 key={stop.location.id}
-                stop={stop}
+                stop={{ ...stop, ...dayLabels[i] }}
                 isFirst={i === 0}
                 isLast={i === stops.length - 1}
               />

--- a/src/features/booking/booking-drawer.stories.tsx
+++ b/src/features/booking/booking-drawer.stories.tsx
@@ -22,6 +22,7 @@ export const RoundMiddleStop = () => {
         commuteType="ROUND"
         commuteDate={STORY_DATE}
         stop={null}
+        commuteStops={[]}
         driver={null}
         isFirstStop={false}
         isLastStop={false}
@@ -43,6 +44,7 @@ export const RoundFirstStop = () => {
         commuteType="ROUND"
         commuteDate={STORY_DATE}
         stop={null}
+        commuteStops={[]}
         driver={null}
         isFirstStop={true}
         isLastStop={false}
@@ -64,6 +66,7 @@ export const RoundLastStop = () => {
         commuteType="ROUND"
         commuteDate={STORY_DATE}
         stop={null}
+        commuteStops={[]}
         driver={null}
         isFirstStop={false}
         isLastStop={true}
@@ -85,6 +88,7 @@ export const OneWayCommute = () => {
         commuteType="ONEWAY"
         commuteDate={STORY_DATE}
         stop={null}
+        commuteStops={[]}
         driver={null}
         isFirstStop={false}
         isLastStop={false}

--- a/src/features/booking/booking-drawer.tsx
+++ b/src/features/booking/booking-drawer.tsx
@@ -103,6 +103,12 @@ export const BookingDrawer = (props: {
   commuteType: CommuteType;
   commuteDate: Date;
   stop: StopEnriched | null;
+  /**
+   * All the commute's stops in order. Passed to the summary so the day-offset
+   * of the single booked stop is computed against the whole trip (a stop after
+   * a midnight crossing would otherwise be mislabelled when shown in isolation).
+   */
+  commuteStops: StopEnriched[];
   driver: UserSummary | null;
   isFirstStop: boolean;
   isLastStop: boolean;
@@ -172,6 +178,7 @@ export const BookingDrawer = (props: {
                 date={props.commuteDate}
                 typeLabel={t(`commute:list.type.${props.commuteType}`)}
                 stops={[props.stop]}
+                tripStops={props.commuteStops}
               />
             )}
             {tripTypeOptions.length > 1 && (

--- a/src/features/commute-template/schema.ts
+++ b/src/features/commute-template/schema.ts
@@ -41,26 +41,26 @@ export const zFormFieldsCommuteTemplate = () =>
       const rules = createStopOrderRules(data);
 
       data.stops.forEach((stop, index) => {
-        if (!rules.shouldInwardBeAfterOutward(stop)) {
+        if (!rules.shouldInwardDifferFromOutward(stop)) {
           ctx.addIssue({
             code: 'custom',
-            message: t('commuteTemplate:form.errors.inwardBeforeOutward'),
+            message: t('commuteTemplate:form.errors.inwardSameAsOutward'),
             path: ['stops', index, 'inwardTime'],
           });
         }
 
-        if (!rules.shouldOutwardBeIncreasing(stop, index)) {
+        if (!rules.shouldOutwardDifferFromPrev(stop, index)) {
           ctx.addIssue({
             code: 'custom',
-            message: t('commuteTemplate:form.errors.outwardNotIncreasing'),
+            message: t('commuteTemplate:form.errors.outwardSameAsPrev'),
             path: ['stops', index, 'outwardTime'],
           });
         }
 
-        if (!rules.shouldInwardBeDecreasing(stop, index)) {
+        if (!rules.shouldInwardDifferFromPrev(stop, index)) {
           ctx.addIssue({
             code: 'custom',
-            message: t('commuteTemplate:form.errors.inwardNotDecreasing'),
+            message: t('commuteTemplate:form.errors.inwardSameAsPrev'),
             path: ['stops', index, 'inwardTime'],
           });
         }

--- a/src/features/commute/app/page-commute-new.tsx
+++ b/src/features/commute/app/page-commute-new.tsx
@@ -250,6 +250,7 @@ export const PageCommuteNew = ({
                 <StepOutwardStops
                   {...asCommuteBase(form)}
                   ns="commute"
+                  tripDate={currentDate}
                   defaultStop={{
                     locationId: '',
                     outwardTime: '',
@@ -274,13 +275,21 @@ export const PageCommuteNew = ({
                         );
                       }}
                     >
-                      <StepInwardStops {...asCommuteBase(form)} ns="commute" />
+                      <StepInwardStops
+                        {...asCommuteBase(form)}
+                        ns="commute"
+                        tripDate={currentDate}
+                      />
                     </MultiStepFormStep>
                   ) : null
                 }
               />
               <MultiStepFormStep name={t('commute:stepper.recap')}>
-                <StepRecap {...asCommuteBase(form)} ns="commute" />
+                <StepRecap
+                  {...asCommuteBase(form)}
+                  ns="commute"
+                  tripDate={currentDate}
+                />
               </MultiStepFormStep>
             </PageLayoutContent>
             <MultiStepFormNavigation

--- a/src/features/commute/app/page-commute-new.tsx
+++ b/src/features/commute/app/page-commute-new.tsx
@@ -250,7 +250,6 @@ export const PageCommuteNew = ({
                 <StepOutwardStops
                   {...asCommuteBase(form)}
                   ns="commute"
-                  tripDate={currentDate}
                   defaultStop={{
                     locationId: '',
                     outwardTime: '',
@@ -275,11 +274,7 @@ export const PageCommuteNew = ({
                         );
                       }}
                     >
-                      <StepInwardStops
-                        {...asCommuteBase(form)}
-                        ns="commute"
-                        tripDate={currentDate}
-                      />
+                      <StepInwardStops {...asCommuteBase(form)} ns="commute" />
                     </MultiStepFormStep>
                   ) : null
                 }

--- a/src/features/commute/app/page-commute-update.tsx
+++ b/src/features/commute/app/page-commute-update.tsx
@@ -177,7 +177,6 @@ export const PageCommuteUpdate = (props: { id: string; orgSlug: string }) => {
                 <StepOutwardStops
                   {...asCommuteBase(form)}
                   ns="commute"
-                  tripDate={commuteQuery.data?.date}
                   defaultStop={{
                     locationId: '',
                     outwardTime: '',
@@ -202,11 +201,7 @@ export const PageCommuteUpdate = (props: { id: string; orgSlug: string }) => {
                         );
                       }}
                     >
-                      <StepInwardStops
-                        {...asCommuteBase(form)}
-                        ns="commute"
-                        tripDate={commuteQuery.data?.date}
-                      />
+                      <StepInwardStops {...asCommuteBase(form)} ns="commute" />
                     </MultiStepFormStep>
                   ) : null
                 }

--- a/src/features/commute/app/page-commute-update.tsx
+++ b/src/features/commute/app/page-commute-update.tsx
@@ -177,6 +177,7 @@ export const PageCommuteUpdate = (props: { id: string; orgSlug: string }) => {
                 <StepOutwardStops
                   {...asCommuteBase(form)}
                   ns="commute"
+                  tripDate={commuteQuery.data?.date}
                   defaultStop={{
                     locationId: '',
                     outwardTime: '',
@@ -201,7 +202,11 @@ export const PageCommuteUpdate = (props: { id: string; orgSlug: string }) => {
                         );
                       }}
                     >
-                      <StepInwardStops {...asCommuteBase(form)} ns="commute" />
+                      <StepInwardStops
+                        {...asCommuteBase(form)}
+                        ns="commute"
+                        tripDate={commuteQuery.data?.date}
+                      />
                     </MultiStepFormStep>
                   ) : null
                 }
@@ -221,6 +226,7 @@ export const PageCommuteUpdate = (props: { id: string; orgSlug: string }) => {
                   <StepRecap
                     {...asCommuteBase(form)}
                     ns="commute"
+                    tripDate={commuteQuery.data?.date}
                     passengersByLocationId={passengersByLocationId}
                   />
                 </div>

--- a/src/features/commute/app/page-commutes.tsx
+++ b/src/features/commute/app/page-commutes.tsx
@@ -212,7 +212,6 @@ export const PageCommutes = () => {
                                   inwardDeparture={
                                     item.stops.at(-1)?.inwardTime ?? undefined
                                   }
-                                  date={item.date}
                                   stops={item.stops}
                                   passengers={[...acceptedPassengers.values()]}
                                   badge={

--- a/src/features/commute/app/page-commutes.tsx
+++ b/src/features/commute/app/page-commutes.tsx
@@ -212,6 +212,7 @@ export const PageCommutes = () => {
                                   inwardDeparture={
                                     item.stops.at(-1)?.inwardTime ?? undefined
                                   }
+                                  date={item.date}
                                   stops={item.stops}
                                   passengers={[...acceptedPassengers.values()]}
                                   badge={

--- a/src/features/commute/card-commute.tsx
+++ b/src/features/commute/card-commute.tsx
@@ -140,6 +140,8 @@ type CardCommuteHeaderProps = {
   inwardTaken?: number;
   outwardDeparture?: string;
   inwardDeparture?: string;
+  /** Commute date, used to show the exact day on stops crossing midnight. */
+  date?: Date | null;
   stops?: StopEnriched[];
   passengers?: PassengerSummary[];
   badge?: React.ReactNode;
@@ -205,6 +207,7 @@ function CardCommuteHeader({
   inwardTaken,
   outwardDeparture,
   inwardDeparture,
+  date,
   stops,
   passengers,
   badge,
@@ -267,6 +270,7 @@ function CardCommuteHeader({
         <HeaderStopsTimeline
           stops={stops}
           renderStopActions={renderStopActions}
+          tripDate={date}
         />
       )}
     </>

--- a/src/features/commute/card-commute.tsx
+++ b/src/features/commute/card-commute.tsx
@@ -140,8 +140,6 @@ type CardCommuteHeaderProps = {
   inwardTaken?: number;
   outwardDeparture?: string;
   inwardDeparture?: string;
-  /** Commute date, used to show the exact day on stops crossing midnight. */
-  date?: Date | null;
   stops?: StopEnriched[];
   passengers?: PassengerSummary[];
   badge?: React.ReactNode;
@@ -207,7 +205,6 @@ function CardCommuteHeader({
   inwardTaken,
   outwardDeparture,
   inwardDeparture,
-  date,
   stops,
   passengers,
   badge,
@@ -270,7 +267,6 @@ function CardCommuteHeader({
         <HeaderStopsTimeline
           stops={stops}
           renderStopActions={renderStopActions}
-          tripDate={date}
         />
       )}
     </>

--- a/src/features/commute/form-commute-rules.ts
+++ b/src/features/commute/form-commute-rules.ts
@@ -4,10 +4,12 @@ import type {
   FormFieldsCommute,
   FormFieldsStopInput,
 } from '@/features/commute/schema';
+import { computeDayOffsets } from '@/features/commute/time-utils';
 
-const isTimeInFuture = (date: Date, time: string) => {
+const isTimeInFuture = (date: Date, time: string, dayOffset = 0) => {
   const [hours = 0, minutes = 0] = time.split(':').map(Number);
-  return dayjs(date).hour(hours).minute(minutes).isAfter(dayjs());
+  const instant = dayjs(date).hour(hours).minute(minutes).add(dayOffset, 'day');
+  return instant.isAfter(dayjs());
 };
 
 type StopOrderRulesData = {
@@ -21,15 +23,21 @@ export const createStopOrderRules = (data: StopOrderRulesData) => {
   return {
     isRound,
 
-    shouldInwardBeAfterOutward: (
+    // A return time earlier than the outward time is read as the next day
+    // (e.g. outward 15:00, inward 02:00), so any distinct time is valid.
+    // Only an identical time is rejected (zero-length round trip).
+    shouldInwardDifferFromOutward: (
       stop: Pick<FormFieldsStopInput, 'outwardTime' | 'inwardTime'>
     ) =>
       !isRound ||
       !stop.inwardTime ||
       !stop.outwardTime ||
-      stop.inwardTime > stop.outwardTime,
+      stop.inwardTime !== stop.outwardTime,
 
-    shouldOutwardBeIncreasing: (
+    // Across stops a later time means progress within the day, an earlier
+    // time means the journey crossed midnight — both are valid. Only an
+    // identical time as the previous stop is rejected.
+    shouldOutwardDifferFromPrev: (
       stop: Pick<FormFieldsStopInput, 'outwardTime'>,
       index: number
     ) => {
@@ -38,11 +46,13 @@ export const createStopOrderRules = (data: StopOrderRulesData) => {
       return (
         !stop.outwardTime ||
         !prevStop?.outwardTime ||
-        stop.outwardTime > prevStop.outwardTime
+        stop.outwardTime !== prevStop.outwardTime
       );
     },
 
-    shouldInwardBeDecreasing: (
+    // Same reasoning for the return leg: distinct adjacent times are valid
+    // (a smaller value simply crossed midnight), identical ones are not.
+    shouldInwardDifferFromPrev: (
       stop: Pick<FormFieldsStopInput, 'inwardTime'>,
       index: number
     ) => {
@@ -51,7 +61,7 @@ export const createStopOrderRules = (data: StopOrderRulesData) => {
       return (
         !stop.inwardTime ||
         !prevStop?.inwardTime ||
-        stop.inwardTime < prevStop.inwardTime
+        stop.inwardTime !== prevStop.inwardTime
       );
     },
   };
@@ -66,24 +76,35 @@ export const createCommuteRules = (data: FormFieldsCommute) => {
 
   const stopOrderRules = createStopOrderRules(data);
 
-  const isFutureTime = (time?: string) =>
-    !time || isTimeInFuture(data.date, time);
+  // Cumulative day offset per stop along the real trip chronology, so a leg
+  // that crosses midnight pushes everything after it to the next day.
+  const dayOffsets = computeDayOffsets(data.stops);
 
   return {
     isToday,
     ...stopOrderRules,
 
-    isOutwardInFuture: (stop: FormFieldsStopInput) => {
+    isOutwardInFuture: (stop: FormFieldsStopInput, index: number) => {
       if (isInPast) return false;
       if (!isToday) return true;
-      return isFutureTime(stop.outwardTime);
+      if (!stop.outwardTime) return true;
+      return isTimeInFuture(
+        data.date,
+        stop.outwardTime,
+        dayOffsets.outward[index] ?? 0
+      );
     },
 
-    isInwardInFuture: (stop: FormFieldsStopInput) => {
+    isInwardInFuture: (stop: FormFieldsStopInput, index: number) => {
       if (isInPast) return false;
       if (!isToday) return true;
       if (!stopOrderRules.isRound) return true;
-      return isFutureTime(stop.inwardTime || undefined);
+      if (!stop.inwardTime) return true;
+      return isTimeInFuture(
+        data.date,
+        stop.inwardTime,
+        dayOffsets.inward[index] ?? 0
+      );
     },
   };
 };

--- a/src/features/commute/form-commute-rules.unit.test.ts
+++ b/src/features/commute/form-commute-rules.unit.test.ts
@@ -130,11 +130,17 @@ describe('stopDayLabel', () => {
 
 describe('createCommuteRules — return crossing midnight (today)', () => {
   // Reported bug: departure 15:00, return 02:00 the next day.
-  const data = roundTrip([
-    { outwardTime: '15:00', inwardTime: '02:20' },
-    { outwardTime: '15:30', inwardTime: '02:00' },
-  ]);
-  const rules = createCommuteRules(data);
+  // Built inside `beforeEach` (after the fake timers are set) so the "now"
+  // captured by createCommuteRules is the frozen NOW, not the real clock.
+  let data: ReturnType<typeof roundTrip>;
+  let rules: ReturnType<typeof createCommuteRules>;
+  beforeEach(() => {
+    data = roundTrip([
+      { outwardTime: '15:00', inwardTime: '02:20' },
+      { outwardTime: '15:30', inwardTime: '02:00' },
+    ]);
+    rules = createCommuteRules(data);
+  });
 
   it('accepts the return order (02:00 is read as next day)', () => {
     expect(rules.shouldInwardDifferFromOutward(data.stops[1]!)).toBe(true);
@@ -152,14 +158,14 @@ describe('createCommuteRules — return crossing midnight (today)', () => {
 });
 
 describe('createCommuteRules — outward leg crossing midnight (today)', () => {
-  // Departure 23:30, arrival 00:15 the next day.
-  const data = roundTrip([
-    { outwardTime: '23:30', inwardTime: '02:30' },
-    { outwardTime: '00:15', inwardTime: '02:00' },
-  ]);
-  const rules = createCommuteRules(data);
-
   it('treats the post-midnight arrival outward time as next day (future)', () => {
+    // Departure 23:30, arrival 00:15 the next day. Built inside the test so it
+    // sees the frozen NOW set by the fake timers.
+    const data = roundTrip([
+      { outwardTime: '23:30', inwardTime: '02:30' },
+      { outwardTime: '00:15', inwardTime: '02:00' },
+    ]);
+    const rules = createCommuteRules(data);
     expect(rules.isOutwardInFuture(data.stops[1]!, 1)).toBe(true);
   });
 });

--- a/src/features/commute/form-commute-rules.unit.test.ts
+++ b/src/features/commute/form-commute-rules.unit.test.ts
@@ -109,22 +109,24 @@ describe('tripCrossesMidnight', () => {
 });
 
 describe('stopDayLabel', () => {
+  // Mirrors the offset-aware i18n fallback: "Jour J" at 0, "Lendemain" at +1,
+  // "+N jours" beyond.
+  const dayBadge = (offset: number) =>
+    offset === 0 ? 'Jour J' : offset === 1 ? 'Lendemain' : `+${offset} jours`;
+
   it('shows no badge when the trip stays on a single day', () => {
-    expect(stopDayLabel(TODAY, 0, false, 'Lendemain')).toBeNull();
-    expect(stopDayLabel(TODAY, 1, false, 'Lendemain')).toBeNull();
+    expect(stopDayLabel(0, false, dayBadge)).toBeNull();
+    expect(stopDayLabel(1, false, dayBadge)).toBeNull();
   });
 
-  it('labels every stop with its exact date once the trip crosses midnight', () => {
-    // Day 0 stops are labelled too, so the reader can tell the days apart.
-    expect(stopDayLabel(TODAY, 0, true, 'Lendemain')).toBe('29/06/2026');
-    expect(stopDayLabel(TODAY, 1, true, 'Lendemain')).toBe('30/06/2026');
-    expect(stopDayLabel(TODAY, 2, true, 'Lendemain')).toBe('01/07/2026');
+  it('labels a day-0 stop with "Jour J" when the trip crosses midnight', () => {
+    expect(stopDayLabel(0, true, dayBadge)).toBe('Jour J');
   });
 
-  it('falls back to the generic label (crossed stops only) without a date', () => {
-    expect(stopDayLabel(null, 0, true, 'Lendemain')).toBeNull();
-    expect(stopDayLabel(null, 1, true, 'Lendemain')).toBe('Lendemain');
-    expect(stopDayLabel(undefined, 1, true, 'Lendemain')).toBe('Lendemain');
+  it('labels a shifted stop with a relative day badge once the trip crosses midnight', () => {
+    expect(stopDayLabel(1, true, dayBadge)).toBe('Lendemain');
+    expect(stopDayLabel(2, true, dayBadge)).toBe('+2 jours');
+    expect(stopDayLabel(3, true, dayBadge)).toBe('+3 jours');
   });
 });
 

--- a/src/features/commute/form-commute-rules.unit.test.ts
+++ b/src/features/commute/form-commute-rules.unit.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createCommuteRules } from '@/features/commute/form-commute-rules';
+import { zFormFieldsCommute } from '@/features/commute/schema';
+import {
+  computeDayOffsets,
+  isNextDay,
+  stopDayLabel,
+  tripCrossesMidnight,
+} from '@/features/commute/time-utils';
+
+// Freeze "now" so the today/future checks are deterministic.
+const NOW = new Date('2026-06-29T10:59:00');
+const TODAY = new Date('2026-06-29T08:00:00');
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const roundTrip = (
+  stops: Array<{ outwardTime: string; inwardTime?: string | null }>
+) => ({
+  date: TODAY,
+  seats: 1,
+  type: 'ROUND' as const,
+  comment: null,
+  stops: stops.map((s, i) => ({ ...s, locationId: `loc-${i}` })),
+});
+
+describe('isNextDay', () => {
+  it('flags a clock value smaller than the reference as next day', () => {
+    expect(isNextDay('23:30', '02:00')).toBe(true);
+    expect(isNextDay('15:00', '02:00')).toBe(true);
+  });
+
+  it('does not flag a later or equal time', () => {
+    expect(isNextDay('08:00', '17:00')).toBe(false);
+    expect(isNextDay('23:30', '23:30')).toBe(false);
+  });
+
+  it('is safe with missing values', () => {
+    expect(isNextDay(undefined, '02:00')).toBe(false);
+    expect(isNextDay('23:30', null)).toBe(false);
+  });
+});
+
+describe('computeDayOffsets', () => {
+  it('keeps everything on day 0 when nothing crosses midnight', () => {
+    const { outward, inward } = computeDayOffsets([
+      { outwardTime: '08:00', inwardTime: '17:30' },
+      { outwardTime: '08:30', inwardTime: '17:00' },
+    ]);
+    expect(outward).toEqual([0, 0]);
+    expect(inward).toEqual([0, 0]);
+  });
+
+  it('flags the return as next day when it crosses midnight', () => {
+    const { outward, inward } = computeDayOffsets([
+      { outwardTime: '15:00', inwardTime: '02:20' },
+      { outwardTime: '15:30', inwardTime: '02:00' },
+    ]);
+    expect(outward).toEqual([0, 0]);
+    expect(inward).toEqual([1, 1]);
+  });
+
+  it('forces the return departure to next day when the outward leg crosses midnight', () => {
+    // Departure 23:30 (day 0), arrival 00:15 (day 1). The return departs from
+    // the arrival stop at 23:45 — a larger clock value than the departure, yet
+    // it must still be the next day because the outward already crossed.
+    const { outward, inward } = computeDayOffsets([
+      { outwardTime: '23:30', inwardTime: '00:30' },
+      { outwardTime: '00:15', inwardTime: '23:45' },
+    ]);
+    expect(outward).toEqual([0, 1]);
+    // Return departure (index 1) is forced to day 1 even though 23:45 > 23:30.
+    expect(inward[1]).toBe(1);
+  });
+});
+
+describe('tripCrossesMidnight', () => {
+  it('is false when nothing crosses midnight', () => {
+    const stops = [
+      { outwardTime: '08:00', inwardTime: '17:30' },
+      { outwardTime: '08:30', inwardTime: '17:00' },
+    ];
+    expect(tripCrossesMidnight(stops, computeDayOffsets(stops))).toBe(false);
+  });
+
+  it('is true as soon as one leg crosses midnight', () => {
+    const stops = [
+      { outwardTime: '15:00', inwardTime: '02:20' },
+      { outwardTime: '15:30', inwardTime: '02:00' },
+    ];
+    expect(tripCrossesMidnight(stops, computeDayOffsets(stops))).toBe(true);
+  });
+
+  it('ignores a day offset carried by a missing inward time', () => {
+    const stops = [
+      { outwardTime: '08:00', inwardTime: null },
+      { outwardTime: '08:30', inwardTime: null },
+    ];
+    expect(tripCrossesMidnight(stops, computeDayOffsets(stops))).toBe(false);
+  });
+});
+
+describe('stopDayLabel', () => {
+  it('shows no badge when the trip stays on a single day', () => {
+    expect(stopDayLabel(TODAY, 0, false, 'Lendemain')).toBeNull();
+    expect(stopDayLabel(TODAY, 1, false, 'Lendemain')).toBeNull();
+  });
+
+  it('labels every stop with its exact date once the trip crosses midnight', () => {
+    // Day 0 stops are labelled too, so the reader can tell the days apart.
+    expect(stopDayLabel(TODAY, 0, true, 'Lendemain')).toBe('29/06/2026');
+    expect(stopDayLabel(TODAY, 1, true, 'Lendemain')).toBe('30/06/2026');
+    expect(stopDayLabel(TODAY, 2, true, 'Lendemain')).toBe('01/07/2026');
+  });
+
+  it('falls back to the generic label (crossed stops only) without a date', () => {
+    expect(stopDayLabel(null, 0, true, 'Lendemain')).toBeNull();
+    expect(stopDayLabel(null, 1, true, 'Lendemain')).toBe('Lendemain');
+    expect(stopDayLabel(undefined, 1, true, 'Lendemain')).toBe('Lendemain');
+  });
+});
+
+describe('createCommuteRules — return crossing midnight (today)', () => {
+  // Reported bug: departure 15:00, return 02:00 the next day.
+  const data = roundTrip([
+    { outwardTime: '15:00', inwardTime: '02:20' },
+    { outwardTime: '15:30', inwardTime: '02:00' },
+  ]);
+  const rules = createCommuteRules(data);
+
+  it('accepts the return order (02:00 is read as next day)', () => {
+    expect(rules.shouldInwardDifferFromOutward(data.stops[1]!)).toBe(true);
+  });
+
+  it('treats the next-day return as being in the future', () => {
+    expect(rules.isInwardInFuture(data.stops[0]!, 0)).toBe(true);
+    expect(rules.isInwardInFuture(data.stops[1]!, 1)).toBe(true);
+  });
+
+  it('keeps the outward times valid', () => {
+    expect(rules.isOutwardInFuture(data.stops[0]!, 0)).toBe(true);
+    expect(rules.isOutwardInFuture(data.stops[1]!, 1)).toBe(true);
+  });
+});
+
+describe('createCommuteRules — outward leg crossing midnight (today)', () => {
+  // Departure 23:30, arrival 00:15 the next day.
+  const data = roundTrip([
+    { outwardTime: '23:30', inwardTime: '02:30' },
+    { outwardTime: '00:15', inwardTime: '02:00' },
+  ]);
+  const rules = createCommuteRules(data);
+
+  it('treats the post-midnight arrival outward time as next day (future)', () => {
+    expect(rules.isOutwardInFuture(data.stops[1]!, 1)).toBe(true);
+  });
+});
+
+describe('createCommuteRules — genuine errors are still caught', () => {
+  it('rejects an outward time already past today (no midnight crossing)', () => {
+    const data = roundTrip([
+      { outwardTime: '08:00', inwardTime: '17:00' },
+      { outwardTime: '09:00', inwardTime: '16:30' },
+    ]);
+    const rules = createCommuteRules(data);
+    expect(rules.isOutwardInFuture(data.stops[0]!, 0)).toBe(false);
+  });
+
+  it('rejects an identical outward/inward time', () => {
+    const data = roundTrip([{ outwardTime: '23:30', inwardTime: '23:30' }]);
+    const rules = createCommuteRules(data);
+    expect(rules.shouldInwardDifferFromOutward(data.stops[0]!)).toBe(false);
+  });
+});
+
+describe('zFormFieldsCommute — end to end', () => {
+  it('validates a round trip whose return crosses midnight', () => {
+    const result = zFormFieldsCommute().safeParse(
+      roundTrip([
+        { outwardTime: '23:30', inwardTime: '02:20' },
+        { outwardTime: '23:50', inwardTime: '02:00' },
+      ])
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/features/commute/form-commute/step-inward-stops.tsx
+++ b/src/features/commute/form-commute/step-inward-stops.tsx
@@ -30,15 +30,12 @@ type StepInwardStopsProps = {
   control: Control<FormFieldsCommuteBase>;
   setValue: UseFormReturn<FormFieldsCommuteBase>['setValue'];
   ns: 'commute' | 'commuteTemplate';
-  /** Commute date, used to show the exact date when a leg crosses midnight. */
-  tripDate?: Date | null;
 };
 
 export const StepInwardStops = ({
   control,
   setValue,
   ns,
-  tripDate,
 }: StepInwardStopsProps) => {
   const { t } = useTranslation([ns, 'common']);
   const { stops, autoComputedIndices } = useAutoInwardTimes({
@@ -100,10 +97,9 @@ export const StepInwardStops = ({
                 {t(`${ns}:form.inwardTime`)}
                 <StopDayBadge
                   label={stopDayLabel(
-                    tripDate,
                     dayOffsets.inward[index] ?? 0,
                     hasDayChange,
-                    t('common:nextDay')
+                    (offset) => t('common:dayBadge', { count: offset })
                   )}
                   offset={dayOffsets.inward[index] ?? 0}
                 />

--- a/src/features/commute/form-commute/step-inward-stops.tsx
+++ b/src/features/commute/form-commute/step-inward-stops.tsx
@@ -105,6 +105,7 @@ export const StepInwardStops = ({
                     hasDayChange,
                     t('common:nextDay')
                   )}
+                  offset={dayOffsets.inward[index] ?? 0}
                 />
                 {autoComputedIndices.has(index) && (
                   <FormFieldHelper>

--- a/src/features/commute/form-commute/step-inward-stops.tsx
+++ b/src/features/commute/form-commute/step-inward-stops.tsx
@@ -18,20 +18,29 @@ import {
 } from '@/components/ui/popover';
 
 import type { FormFieldsCommuteBase } from '@/features/commute/schema';
+import { StopDayBadge } from '@/features/commute/stops-timeline';
+import {
+  computeDayOffsets,
+  stopDayLabel,
+  tripCrossesMidnight,
+} from '@/features/commute/time-utils';
 import { useAutoInwardTimes } from '@/features/commute/use-auto-inward-times';
 
 type StepInwardStopsProps = {
   control: Control<FormFieldsCommuteBase>;
   setValue: UseFormReturn<FormFieldsCommuteBase>['setValue'];
   ns: 'commute' | 'commuteTemplate';
+  /** Commute date, used to show the exact date when a leg crosses midnight. */
+  tripDate?: Date | null;
 };
 
 export const StepInwardStops = ({
   control,
   setValue,
   ns,
+  tripDate,
 }: StepInwardStopsProps) => {
-  const { t } = useTranslation([ns]);
+  const { t } = useTranslation([ns, 'common']);
   const { stops, autoComputedIndices } = useAutoInwardTimes({
     control,
     setValue,
@@ -51,6 +60,9 @@ export const StepInwardStops = ({
       p.items.map((loc) => [loc.id, loc.name] as const)
     ) ?? []
   );
+
+  const dayOffsets = computeDayOffsets(stops ?? []);
+  const hasDayChange = tripCrossesMidnight(stops ?? [], dayOffsets);
 
   // Reverse order so stops are chronological for the return trip
   const reversedIndices = stops
@@ -86,6 +98,14 @@ export const StepInwardStops = ({
             <FormField>
               <FormFieldLabel>
                 {t(`${ns}:form.inwardTime`)}
+                <StopDayBadge
+                  label={stopDayLabel(
+                    tripDate,
+                    dayOffsets.inward[index] ?? 0,
+                    hasDayChange,
+                    t('common:nextDay')
+                  )}
+                />
                 {autoComputedIndices.has(index) && (
                   <FormFieldHelper>
                     <Popover>

--- a/src/features/commute/form-commute/step-outward-stops.tsx
+++ b/src/features/commute/form-commute/step-outward-stops.tsx
@@ -90,6 +90,7 @@ export const StepOutwardStops = ({
                           hasDayChange,
                           t('common:nextDay')
                         )}
+                        offset={dayOffsets.outward[index] ?? 0}
                       />
                     </FormFieldLabel>
                     <FormFieldController

--- a/src/features/commute/form-commute/step-outward-stops.tsx
+++ b/src/features/commute/form-commute/step-outward-stops.tsx
@@ -18,6 +18,12 @@ import {
 import { Button } from '@/components/ui/button';
 
 import type { FormFieldsCommuteBase } from '@/features/commute/schema';
+import { StopDayBadge } from '@/features/commute/stops-timeline';
+import {
+  computeDayOffsets,
+  stopDayLabel,
+  tripCrossesMidnight,
+} from '@/features/commute/time-utils';
 import { FormFieldLocationSelect } from '@/features/location/app/form-field-location-select';
 
 type StepOutwardStopsProps = {
@@ -25,6 +31,8 @@ type StepOutwardStopsProps = {
   setValue: UseFormReturn<FormFieldsCommuteBase>['setValue'];
   ns: 'commute' | 'commuteTemplate';
   defaultStop: FormFieldsCommuteBase['stops'][number];
+  /** Commute date, used to show the exact date when a leg crosses midnight. */
+  tripDate?: Date | null;
 };
 
 export const StepOutwardStops = ({
@@ -32,8 +40,9 @@ export const StepOutwardStops = ({
   setValue,
   ns,
   defaultStop,
+  tripDate,
 }: StepOutwardStopsProps) => {
-  const { t } = useTranslation([ns]);
+  const { t } = useTranslation([ns, 'common']);
   const { fields, insert, remove } = useFieldArray({
     control,
     name: 'stops',
@@ -43,6 +52,8 @@ export const StepOutwardStops = ({
     name: 'stops',
   });
   const { containerRef, focusFieldAt } = useFocusFieldAt();
+  const dayOffsets = computeDayOffsets(stops ?? []);
+  const hasDayChange = tripCrossesMidnight(stops ?? [], dayOffsets);
 
   return (
     <div ref={containerRef} className="flex flex-col gap-3">
@@ -72,6 +83,14 @@ export const StepOutwardStops = ({
                   <FormField>
                     <FormFieldLabel required>
                       {t(`${ns}:form.outwardTime`)}
+                      <StopDayBadge
+                        label={stopDayLabel(
+                          tripDate,
+                          dayOffsets.outward[index] ?? 0,
+                          hasDayChange,
+                          t('common:nextDay')
+                        )}
+                      />
                     </FormFieldLabel>
                     <FormFieldController
                       type="time"

--- a/src/features/commute/form-commute/step-outward-stops.tsx
+++ b/src/features/commute/form-commute/step-outward-stops.tsx
@@ -31,8 +31,6 @@ type StepOutwardStopsProps = {
   setValue: UseFormReturn<FormFieldsCommuteBase>['setValue'];
   ns: 'commute' | 'commuteTemplate';
   defaultStop: FormFieldsCommuteBase['stops'][number];
-  /** Commute date, used to show the exact date when a leg crosses midnight. */
-  tripDate?: Date | null;
 };
 
 export const StepOutwardStops = ({
@@ -40,7 +38,6 @@ export const StepOutwardStops = ({
   setValue,
   ns,
   defaultStop,
-  tripDate,
 }: StepOutwardStopsProps) => {
   const { t } = useTranslation([ns, 'common']);
   const { fields, insert, remove } = useFieldArray({
@@ -85,10 +82,9 @@ export const StepOutwardStops = ({
                       {t(`${ns}:form.outwardTime`)}
                       <StopDayBadge
                         label={stopDayLabel(
-                          tripDate,
                           dayOffsets.outward[index] ?? 0,
                           hasDayChange,
-                          t('common:nextDay')
+                          (offset) => t('common:dayBadge', { count: offset })
                         )}
                         offset={dayOffsets.outward[index] ?? 0}
                       />

--- a/src/features/commute/form-commute/step-recap.tsx
+++ b/src/features/commute/form-commute/step-recap.tsx
@@ -1,5 +1,4 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import dayjs from 'dayjs';
 import { useMemo } from 'react';
 import { type Control, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -18,19 +17,31 @@ import {
   type StopForTimeline,
   StopsTimelineItem,
 } from '@/features/commute/stops-timeline';
+import {
+  computeDayOffsets,
+  formatTripDate,
+  stopDayLabel,
+  tripCrossesMidnight,
+} from '@/features/commute/time-utils';
 
 type StepRecapProps = {
   control: Control<FormFieldsCommuteBase>;
   ns: 'commute' | 'commuteTemplate';
   passengersByLocationId?: Map<string, StopPassenger[]>;
+  /**
+   * Commute date, used to show the exact date when a leg crosses midnight.
+   * Falls back to the form's `date` field when omitted (creation flow).
+   */
+  tripDate?: Date | null;
 };
 
 export const StepRecap = ({
   control,
   ns,
   passengersByLocationId,
+  tripDate: tripDateProp,
 }: StepRecapProps) => {
-  const { t } = useTranslation([ns, 'commute']);
+  const { t } = useTranslation([ns, 'commute', 'common']);
   const values = useWatch({ control }) as FormFieldsCommuteBase &
     Record<string, unknown>;
 
@@ -61,9 +72,26 @@ export const StepRecap = ({
   const OnewayIcon = tripTypeIcons.ONEWAY;
   const ReturnIcon = tripTypeIcons.RETURN;
 
+  // Cumulative day offset per stop, so a leg crossing midnight flags every
+  // later time (e.g. the return departure) as happening the next day.
+  // `hasDayChange` answers: does any displayed stop land on a different day?
+  const dayOffsets = computeDayOffsets(stops ?? []);
+  const hasDayChange = tripCrossesMidnight(stops ?? [], dayOffsets);
+
+  const tripDate =
+    tripDateProp ??
+    (ns === 'commute' ? (values.date as Date | undefined) : null);
+
+  // Shared with the form steps: when the trip crosses midnight, every stop
+  // carries its exact date so the reader can tell the days apart; otherwise
+  // the single global date badge is enough and stops carry no per-stop label.
+  const stopDateLabel = (dayOffset: number) =>
+    stopDayLabel(tripDate, dayOffset, hasDayChange, t('common:nextDay'));
+
   const toTimelineStop = (
     locationId: string,
-    time: string
+    time: string,
+    dayOffset: number
   ): StopForTimeline => {
     const loc = locationsMap.get(locationId);
     return {
@@ -74,28 +102,36 @@ export const StepRecap = ({
       },
       outwardTime: time,
       inwardTime: null,
+      outwardDayLabel: stopDateLabel(dayOffset),
       passengers: passengersByLocationId?.get(locationId),
     };
   };
 
-  const outwardStops = (stops ?? []).map((s) =>
-    toTimelineStop(s.locationId, s.outwardTime)
+  const outwardStops = (stops ?? []).map((s, i) =>
+    toTimelineStop(s.locationId, s.outwardTime, dayOffsets.outward[i] ?? 0)
   );
 
-  const inwardStops = [...(stops ?? [])]
+  const inwardStops = (stops ?? [])
+    .map((s, i) => ({ s, i }))
     .reverse()
-    .flatMap((s) =>
-      s.inwardTime ? [toTimelineStop(s.locationId, s.inwardTime)] : []
+    .flatMap(({ s, i }) =>
+      s.inwardTime
+        ? [
+            toTimelineStop(
+              s.locationId,
+              s.inwardTime,
+              dayOffsets.inward[i] ?? 0
+            ),
+          ]
+        : []
     );
 
   return (
     <div className="flex flex-col gap-4">
       {/* Meta info */}
       <div className="flex flex-wrap gap-2">
-        {ns === 'commute' && values.date != null && (
-          <Badge variant="secondary">
-            {dayjs(values.date as Date).format('DD/MM/YYYY')}
-          </Badge>
+        {ns === 'commute' && tripDate != null && !hasDayChange && (
+          <Badge variant="secondary">{formatTripDate(tripDate, 0)}</Badge>
         )}
         {ns === 'commuteTemplate' && values.name != null && (
           <Badge variant="secondary">{String(values.name)}</Badge>

--- a/src/features/commute/form-commute/step-recap.tsx
+++ b/src/features/commute/form-commute/step-recap.tsx
@@ -103,6 +103,7 @@ export const StepRecap = ({
       outwardTime: time,
       inwardTime: null,
       outwardDayLabel: stopDateLabel(dayOffset),
+      outwardDayOffset: dayOffset,
       passengers: passengersByLocationId?.get(locationId),
     };
   };

--- a/src/features/commute/form-commute/step-recap.tsx
+++ b/src/features/commute/form-commute/step-recap.tsx
@@ -29,8 +29,10 @@ type StepRecapProps = {
   ns: 'commute' | 'commuteTemplate';
   passengersByLocationId?: Map<string, StopPassenger[]>;
   /**
-   * Commute date, used to show the exact date when a leg crosses midnight.
-   * Falls back to the form's `date` field when omitted (creation flow).
+   * Commute date, shown as the single global trip-date (anchor) badge. The
+   * per-stop badges then express later days relative to it ("Lendemain",
+   * "+2 jours"). Falls back to the form's `date` field when omitted (creation
+   * flow).
    */
   tripDate?: Date | null;
 };
@@ -82,11 +84,13 @@ export const StepRecap = ({
     tripDateProp ??
     (ns === 'commute' ? (values.date as Date | undefined) : null);
 
-  // Shared with the form steps: when the trip crosses midnight, every stop
-  // carries its exact date so the reader can tell the days apart; otherwise
-  // the single global date badge is enough and stops carry no per-stop label.
+  // Shared with the form steps and timelines: when the trip crosses midnight,
+  // each shifted stop carries a relative day badge ("Lendemain", "+2 jours")
+  // anchored to the global trip-date badge below.
   const stopDateLabel = (dayOffset: number) =>
-    stopDayLabel(tripDate, dayOffset, hasDayChange, t('common:nextDay'));
+    stopDayLabel(dayOffset, hasDayChange, (offset) =>
+      t('common:dayBadge', { count: offset })
+    );
 
   const toTimelineStop = (
     locationId: string,
@@ -131,7 +135,7 @@ export const StepRecap = ({
     <div className="flex flex-col gap-4">
       {/* Meta info */}
       <div className="flex flex-wrap gap-2">
-        {ns === 'commute' && tripDate != null && !hasDayChange && (
+        {ns === 'commute' && tripDate != null && (
           <Badge variant="secondary">{formatTripDate(tripDate, 0)}</Badge>
         )}
         {ns === 'commuteTemplate' && values.name != null && (

--- a/src/features/commute/header-stops-timeline.tsx
+++ b/src/features/commute/header-stops-timeline.tsx
@@ -35,11 +35,6 @@ type StopActionsRenderer = (
 type HeaderStopsTimelineProps = {
   stops: HeaderStop[];
   renderStopActions?: StopActionsRenderer;
-  /**
-   * Trip date, used to label stops that fall on a later day when the trip
-   * crosses midnight (e.g. a return departing after midnight).
-   */
-  tripDate?: Date | null;
 };
 
 /**
@@ -149,7 +144,6 @@ function TimelineStopRow({
 export function HeaderStopsTimeline({
   stops,
   renderStopActions,
-  tripDate,
 }: HeaderStopsTimelineProps) {
   const { t } = useTranslation(['commute', 'common']);
 
@@ -161,8 +155,7 @@ export function HeaderStopsTimeline({
   // affected times, consistently with the form recap.
   const dayLabels = computeStopDayLabels(
     stops,
-    tripDate,
-    t('common:nextDay'),
+    (offset) => t('common:dayBadge', { count: offset }),
     dayOffsets
   );
   const labeledStops = stops.map((stop, i) => ({ ...stop, ...dayLabels[i] }));

--- a/src/features/commute/header-stops-timeline.tsx
+++ b/src/features/commute/header-stops-timeline.tsx
@@ -64,12 +64,18 @@ function StopNameRow({ stop }: { stop: StopForTimeline }) {
         <div className="flex shrink-0 items-center gap-1.5 text-sm whitespace-nowrap text-muted-foreground">
           <span className="text-muted-foreground/50">·</span>
           <TripTime type="ONEWAY" time={stop.outwardTime} />
-          <StopDayBadge label={stop.outwardDayLabel} />
+          <StopDayBadge
+            label={stop.outwardDayLabel}
+            offset={stop.outwardDayOffset}
+          />
           {stop.inwardTime && (
             <>
               <span className="text-muted-foreground/50">·</span>
               <TripTime type="RETURN" time={stop.inwardTime} />
-              <StopDayBadge label={stop.inwardDayLabel} />
+              <StopDayBadge
+                label={stop.inwardDayLabel}
+                offset={stop.inwardDayOffset}
+              />
             </>
           )}
         </div>

--- a/src/features/commute/header-stops-timeline.tsx
+++ b/src/features/commute/header-stops-timeline.tsx
@@ -5,16 +5,17 @@ import { cn } from '@/lib/tailwind/utils';
 
 import {
   ActivePassengersBadges,
+  StopDayBadge,
   StopForTimeline,
   TimelineDot,
   TimelineLine,
   TripTime,
 } from '@/features/commute/stops-timeline';
-
-function parseMins(time: string) {
-  const [h, m] = time.split(':');
-  return Number(h ?? 0) * 60 + Number(m ?? 0);
-}
+import {
+  computeDayOffsets,
+  computeStopDayLabels,
+  outwardDurationMinutes,
+} from '@/features/commute/time-utils';
 
 function formatDuration(mins: number) {
   const h = Math.floor(mins / 60);
@@ -34,6 +35,11 @@ type StopActionsRenderer = (
 type HeaderStopsTimelineProps = {
   stops: HeaderStop[];
   renderStopActions?: StopActionsRenderer;
+  /**
+   * Trip date, used to label stops that fall on a later day when the trip
+   * crosses midnight (e.g. a return departing after midnight).
+   */
+  tripDate?: Date | null;
 };
 
 /**
@@ -58,10 +64,12 @@ function StopNameRow({ stop }: { stop: StopForTimeline }) {
         <div className="flex shrink-0 items-center gap-1.5 text-sm whitespace-nowrap text-muted-foreground">
           <span className="text-muted-foreground/50">·</span>
           <TripTime type="ONEWAY" time={stop.outwardTime} />
+          <StopDayBadge label={stop.outwardDayLabel} />
           {stop.inwardTime && (
             <>
               <span className="text-muted-foreground/50">·</span>
               <TripTime type="RETURN" time={stop.inwardTime} />
+              <StopDayBadge label={stop.inwardDayLabel} />
             </>
           )}
         </div>
@@ -135,18 +143,34 @@ function TimelineStopRow({
 export function HeaderStopsTimeline({
   stops,
   renderStopActions,
+  tripDate,
 }: HeaderStopsTimelineProps) {
-  const { t } = useTranslation(['commute']);
+  const { t } = useTranslation(['commute', 'common']);
 
-  const firstStop = stops[0];
-  const lastStop = stops[stops.length - 1];
+  // Computed once and shared between the day labels and the duration below, so
+  // a leg crossing midnight is handled consistently without recomputing.
+  const dayOffsets = computeDayOffsets(stops);
+
+  // Merge per-stop day labels so a leg crossing midnight is shown next to the
+  // affected times, consistently with the form recap.
+  const dayLabels = computeStopDayLabels(
+    stops,
+    tripDate,
+    t('common:nextDay'),
+    dayOffsets
+  );
+  const labeledStops = stops.map((stop, i) => ({ ...stop, ...dayLabels[i] }));
+
+  const firstStop = labeledStops[0];
+  const lastStop = labeledStops[labeledStops.length - 1];
   if (!firstStop || !lastStop) return null;
 
-  const isOnlyStop = stops.length === 1;
-  const intermediateStops = stops.length > 2 ? stops.slice(1, -1) : [];
-  const duration = formatDuration(
-    parseMins(lastStop.outwardTime) - parseMins(firstStop.outwardTime)
-  );
+  const isOnlyStop = labeledStops.length === 1;
+  const intermediateStops =
+    labeledStops.length > 2 ? labeledStops.slice(1, -1) : [];
+  // Day-offset aware so an outward leg crossing midnight (e.g. 23:30 → 00:15)
+  // yields a real elapsed time, not a negative raw-clock difference.
+  const duration = formatDuration(outwardDurationMinutes(stops, dayOffsets));
   const connectorLabel =
     intermediateStops.length > 0
       ? `${t('commute:list.stops', { count: intermediateStops.length })} · ${duration}`

--- a/src/features/commute/schema.ts
+++ b/src/features/commute/schema.ts
@@ -125,7 +125,7 @@ export const zFormFieldsCommute = () =>
       const rules = createCommuteRules(data);
 
       data.stops.forEach((stop, index) => {
-        if (!rules.isOutwardInFuture(stop)) {
+        if (!rules.isOutwardInFuture(stop, index)) {
           ctx.addIssue({
             code: 'custom',
             message: t('commute:form.errors.outwardInPast'),
@@ -133,15 +133,15 @@ export const zFormFieldsCommute = () =>
           });
         }
 
-        if (!rules.shouldInwardBeAfterOutward(stop)) {
+        if (!rules.shouldInwardDifferFromOutward(stop)) {
           ctx.addIssue({
             code: 'custom',
-            message: t('commute:form.errors.inwardBeforeOutward'),
+            message: t('commute:form.errors.inwardSameAsOutward'),
             path: ['stops', index, 'inwardTime'],
           });
         }
 
-        if (!rules.isInwardInFuture(stop)) {
+        if (!rules.isInwardInFuture(stop, index)) {
           ctx.addIssue({
             code: 'custom',
             message: t('commute:form.errors.inwardInPast'),
@@ -149,18 +149,18 @@ export const zFormFieldsCommute = () =>
           });
         }
 
-        if (!rules.shouldOutwardBeIncreasing(stop, index)) {
+        if (!rules.shouldOutwardDifferFromPrev(stop, index)) {
           ctx.addIssue({
             code: 'custom',
-            message: t('commute:form.errors.outwardNotIncreasing'),
+            message: t('commute:form.errors.outwardSameAsPrev'),
             path: ['stops', index, 'outwardTime'],
           });
         }
 
-        if (!rules.shouldInwardBeDecreasing(stop, index)) {
+        if (!rules.shouldInwardDifferFromPrev(stop, index)) {
           ctx.addIssue({
             code: 'custom',
-            message: t('commute:form.errors.inwardNotDecreasing'),
+            message: t('commute:form.errors.inwardSameAsPrev'),
             path: ['stops', index, 'inwardTime'],
           });
         }
@@ -175,26 +175,26 @@ export const zFormFieldsCommuteUpdate = () =>
     const rules = createStopOrderRules(data);
 
     data.stops.forEach((stop, index) => {
-      if (!rules.shouldInwardBeAfterOutward(stop)) {
+      if (!rules.shouldInwardDifferFromOutward(stop)) {
         ctx.addIssue({
           code: 'custom',
-          message: t('commute:form.errors.inwardBeforeOutward'),
+          message: t('commute:form.errors.inwardSameAsOutward'),
           path: ['stops', index, 'inwardTime'],
         });
       }
 
-      if (!rules.shouldOutwardBeIncreasing(stop, index)) {
+      if (!rules.shouldOutwardDifferFromPrev(stop, index)) {
         ctx.addIssue({
           code: 'custom',
-          message: t('commute:form.errors.outwardNotIncreasing'),
+          message: t('commute:form.errors.outwardSameAsPrev'),
           path: ['stops', index, 'outwardTime'],
         });
       }
 
-      if (!rules.shouldInwardBeDecreasing(stop, index)) {
+      if (!rules.shouldInwardDifferFromPrev(stop, index)) {
         ctx.addIssue({
           code: 'custom',
-          message: t('commute:form.errors.inwardNotDecreasing'),
+          message: t('commute:form.errors.inwardSameAsPrev'),
           path: ['stops', index, 'inwardTime'],
         });
       }

--- a/src/features/commute/stops-timeline.tsx
+++ b/src/features/commute/stops-timeline.tsx
@@ -30,15 +30,16 @@ export const TripTime = ({
 };
 
 /**
- * Small secondary badge shown next to a time when it falls on a later day.
+ * Small secondary day badge shown next to a time on a multi-day trip.
  * Renders nothing when `label` is null/undefined. Shared by the form steps, the
  * recap and the read-only timelines so the day indicator looks identical
  * everywhere.
  *
- * On mobile the full date / next-day label would crowd the time block and push
- * the stop name out (it truncates first), so we instead show a compact "+N"
- * day-offset chip — and only for stops actually shifted to a later day. From
- * `sm` up there is room for the full label.
+ * On mobile the full label ("Jour J", "Lendemain", "+2 jours") would crowd the
+ * time block and push the stop name out (it truncates first), so we instead
+ * show a compact "+N" chip — and only for stops actually shifted to a later day
+ * (the day-0 "Jour J" label is desktop-only). From `sm` up there is room for
+ * the full label.
  */
 export const StopDayBadge = ({
   label,
@@ -69,8 +70,8 @@ export type StopForTimeline = Pick<
 > & {
   passengers?: StopPassenger[];
   /**
-   * Badge label shown next to the time when it falls on a later day (the
-   * exact date, or a generic next-day label). Omitted/null = same day.
+   * Relative day badge label shown on a multi-day trip (e.g. "Jour J" on the
+   * trip's own day, "Lendemain", "+2 jours"). Omitted/null = single-day trip.
    */
   outwardDayLabel?: string | null;
   inwardDayLabel?: string | null;
@@ -262,9 +263,10 @@ export const StopsTimeline = ({
   disableLinks,
 }: StopsTimelineProps) => {
   const { t } = useTranslation(['common']);
-  // Only used for dateless contexts (templates) today, so crossed stops show
-  // the generic "next day" badge rather than an exact date.
-  const dayLabels = computeStopDayLabels(stops, null, t('common:nextDay'));
+  // Crossed stops show a relative day badge ("Lendemain", "+2 jours").
+  const dayLabels = computeStopDayLabels(stops, (offset) =>
+    t('common:dayBadge', { count: offset })
+  );
 
   return (
     <div className={cn('flex flex-col', className)}>

--- a/src/features/commute/stops-timeline.tsx
+++ b/src/features/commute/stops-timeline.tsx
@@ -1,5 +1,6 @@
 import { ExternalLinkIcon } from 'lucide-react';
 import { CSSProperties, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { tripTypeIcons } from '@/lib/feature-icons';
 import { cn } from '@/lib/tailwind/utils';
@@ -8,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 
 import { bookingStatusBadgeVariants } from '@/features/booking/booking-status-badge';
 import { StopEnriched, StopPassenger } from '@/features/commute/schema';
+import { computeStopDayLabels } from '@/features/commute/time-utils';
 
 export const TripTime = ({
   type,
@@ -27,10 +29,31 @@ export const TripTime = ({
   );
 };
 
+/**
+ * Small secondary badge shown next to a time when it falls on a later day
+ * (the exact date, or a generic next-day label). Renders nothing when `label`
+ * is null/undefined. Shared by the form steps, the recap and the read-only
+ * timelines so the day indicator looks identical everywhere.
+ */
+export const StopDayBadge = ({ label }: { label?: string | null }) =>
+  label ? (
+    <Badge variant="secondary" size="xs">
+      {label}
+    </Badge>
+  ) : null;
+
 export type StopForTimeline = Pick<
   StopEnriched,
   'location' | 'outwardTime' | 'inwardTime'
-> & { passengers?: StopPassenger[] };
+> & {
+  passengers?: StopPassenger[];
+  /**
+   * Badge label shown next to the time when it falls on a later day (the
+   * exact date, or a generic next-day label). Omitted/null = same day.
+   */
+  outwardDayLabel?: string | null;
+  inwardDayLabel?: string | null;
+};
 
 export const TimelineDot = ({ className }: { className?: string }) => (
   <div
@@ -163,17 +186,19 @@ export const StopsTimelineItem = ({
     <div
       className={cn('flex min-w-0 flex-1 flex-col gap-1.5', !isLast && 'pb-4')}
     >
-      <div className="-mb-1 flex items-center gap-1.5">
+      <div className="-mb-1 flex flex-wrap items-center gap-1.5">
         <span className="truncate text-sm leading-5 font-medium">
           {stop.location.name}
         </span>
         <span className="text-muted-foreground/50">·</span>
         <div className="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground">
           <TripTime type="ONEWAY" time={stop.outwardTime} />
+          <StopDayBadge label={stop.outwardDayLabel} />
           {stop.inwardTime && (
             <>
               <span className="text-muted-foreground/50">·</span>
               <TripTime type="RETURN" time={stop.inwardTime} />
+              <StopDayBadge label={stop.inwardDayLabel} />
             </>
           )}
         </div>
@@ -205,22 +230,29 @@ export const StopsTimeline = ({
   renderActions,
   className,
   disableLinks,
-}: StopsTimelineProps) => (
-  <div className={cn('flex flex-col', className)}>
-    {stops.map((stop, index) => {
-      const isFirst = index === 0;
-      const isLast = index === stops.length - 1;
-      return (
-        <StopsTimelineItem
-          key={stop.id}
-          stop={stop}
-          index={index}
-          isFirst={isFirst}
-          isLast={isLast}
-          disableLinks={disableLinks}
-          actions={renderActions?.(stop, { isFirst, isLast })}
-        />
-      );
-    })}
-  </div>
-);
+}: StopsTimelineProps) => {
+  const { t } = useTranslation(['common']);
+  // Only used for dateless contexts (templates) today, so crossed stops show
+  // the generic "next day" badge rather than an exact date.
+  const dayLabels = computeStopDayLabels(stops, null, t('common:nextDay'));
+
+  return (
+    <div className={cn('flex flex-col', className)}>
+      {stops.map((stop, index) => {
+        const isFirst = index === 0;
+        const isLast = index === stops.length - 1;
+        return (
+          <StopsTimelineItem
+            key={stop.id}
+            stop={{ ...stop, ...dayLabels[index] }}
+            index={index}
+            isFirst={isFirst}
+            isLast={isLast}
+            disableLinks={disableLinks}
+            actions={renderActions?.(stop, { isFirst, isLast })}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/features/commute/stops-timeline.tsx
+++ b/src/features/commute/stops-timeline.tsx
@@ -30,17 +30,38 @@ export const TripTime = ({
 };
 
 /**
- * Small secondary badge shown next to a time when it falls on a later day
- * (the exact date, or a generic next-day label). Renders nothing when `label`
- * is null/undefined. Shared by the form steps, the recap and the read-only
- * timelines so the day indicator looks identical everywhere.
+ * Small secondary badge shown next to a time when it falls on a later day.
+ * Renders nothing when `label` is null/undefined. Shared by the form steps, the
+ * recap and the read-only timelines so the day indicator looks identical
+ * everywhere.
+ *
+ * On mobile the full date / next-day label would crowd the time block and push
+ * the stop name out (it truncates first), so we instead show a compact "+N"
+ * day-offset chip — and only for stops actually shifted to a later day. From
+ * `sm` up there is room for the full label.
  */
-export const StopDayBadge = ({ label }: { label?: string | null }) =>
-  label ? (
-    <Badge variant="secondary" size="xs">
-      {label}
-    </Badge>
-  ) : null;
+export const StopDayBadge = ({
+  label,
+  offset,
+}: {
+  label?: string | null;
+  offset?: number | null;
+}) => {
+  if (!label) return null;
+  const shifted = typeof offset === 'number' && offset >= 1;
+  return (
+    <>
+      {shifted && (
+        <Badge className="sm:hidden" variant="secondary" size="xs">
+          +{offset}
+        </Badge>
+      )}
+      <Badge className="hidden sm:inline-flex" variant="secondary" size="xs">
+        {label}
+      </Badge>
+    </>
+  );
+};
 
 export type StopForTimeline = Pick<
   StopEnriched,
@@ -53,6 +74,9 @@ export type StopForTimeline = Pick<
    */
   outwardDayLabel?: string | null;
   inwardDayLabel?: string | null;
+  /** Cumulative day offset, for the compact "+N" badge shown on mobile. */
+  outwardDayOffset?: number | null;
+  inwardDayOffset?: number | null;
 };
 
 export const TimelineDot = ({ className }: { className?: string }) => (
@@ -193,12 +217,18 @@ export const StopsTimelineItem = ({
         <span className="text-muted-foreground/50">·</span>
         <div className="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground">
           <TripTime type="ONEWAY" time={stop.outwardTime} />
-          <StopDayBadge label={stop.outwardDayLabel} />
+          <StopDayBadge
+            label={stop.outwardDayLabel}
+            offset={stop.outwardDayOffset}
+          />
           {stop.inwardTime && (
             <>
               <span className="text-muted-foreground/50">·</span>
               <TripTime type="RETURN" time={stop.inwardTime} />
-              <StopDayBadge label={stop.inwardDayLabel} />
+              <StopDayBadge
+                label={stop.inwardDayLabel}
+                offset={stop.inwardDayOffset}
+              />
             </>
           )}
         </div>

--- a/src/features/commute/time-utils.ts
+++ b/src/features/commute/time-utils.ts
@@ -159,6 +159,10 @@ export const stopDayLabel = (
 export type StopDayLabels = {
   outwardDayLabel: string | null;
   inwardDayLabel: string | null;
+  // Raw cumulative day offset (0 = trip date, 1 = next day, …) so the day badge
+  // can render a compact "+N" form on mobile instead of the full date label.
+  outwardDayOffset: number;
+  inwardDayOffset: number;
 };
 
 /**
@@ -195,5 +199,7 @@ export const computeStopDayLabels = (
           fallback
         )
       : null,
+    outwardDayOffset: dayOffsets.outward[i] ?? 0,
+    inwardDayOffset: dayOffsets.inward[i] ?? 0,
   }));
 };

--- a/src/features/commute/time-utils.ts
+++ b/src/features/commute/time-utils.ts
@@ -115,8 +115,9 @@ export const outwardDurationMinutes = (
 
 /**
  * A trip date shifted by `dayOffset` days, formatted with the shared
- * `common:short` date format (rather than a hardcoded pattern) so the day
- * badges follow the project-wide date convention.
+ * `common:short` date format (rather than a hardcoded pattern) so it follows
+ * the project-wide date convention. Used for the single global trip-date badge;
+ * the per-stop day badges show a relative label instead (see `stopDayLabel`).
  */
 export const formatTripDate = (tripDate: Date, dayOffset: number): string =>
   dayjs(tripDate).add(dayOffset, 'day').f('common:short');
@@ -136,31 +137,30 @@ export const tripCrossesMidnight = (
   );
 
 /**
- * Per-stop day badge label, shared by the form steps and the recap so they
- * stay consistent.
+ * Per-stop day badge label, shared by the form steps, the recap and the
+ * read-only timelines so they stay consistent.
  *
- * As soon as the trip crosses midnight at least once (`hasDayChange`), **every**
- * stop carries a label so the reader can tell the days apart — its exact date
- * when the trip date is known, or the generic `fallback` (next-day) for dateless
- * templates (and only on the crossed stops in that case). No crossing → no
- * per-stop badge at all.
+ * The label is a **relative** day indicator built from the offset, never an
+ * exact date. It only appears once the trip crosses midnight at least once
+ * (`hasDayChange`); when it does, **every** stop carries a badge built from the
+ * offset-aware `fallback` so the days read consistently (e.g. "Jour J" at 0,
+ * "Lendemain" at +1, "+2 jours" at +2). No crossing → no badge (the single
+ * global trip-date badge is enough).
  */
 export const stopDayLabel = (
-  tripDate: Date | null | undefined,
   dayOffset: number,
   hasDayChange: boolean,
-  fallback: string
+  fallback: (offset: number) => string
 ): string | null => {
   if (!hasDayChange) return null;
-  if (tripDate) return formatTripDate(tripDate, dayOffset);
-  return dayOffset >= 1 ? fallback : null;
+  return fallback(dayOffset);
 };
 
 export type StopDayLabels = {
   outwardDayLabel: string | null;
   inwardDayLabel: string | null;
   // Raw cumulative day offset (0 = trip date, 1 = next day, …) so the day badge
-  // can render a compact "+N" form on mobile instead of the full date label.
+  // can render a compact "+N" form on mobile instead of the full text label.
   outwardDayOffset: number;
   inwardDayOffset: number;
 };
@@ -176,8 +176,7 @@ export type StopDayLabels = {
  */
 export const computeStopDayLabels = (
   stops: ReadonlyArray<DayOffsetStop | undefined>,
-  tripDate: Date | null | undefined,
-  fallback: string,
+  fallback: (offset: number) => string,
   // Optional precomputed offsets, shared with callers that also need the raw
   // offsets (e.g. to compute the trip duration) to avoid recomputing them.
   precomputedOffsets?: DayOffsets
@@ -186,18 +185,12 @@ export const computeStopDayLabels = (
   const hasDayChange = tripCrossesMidnight(stops, dayOffsets);
   return stops.map((stop, i) => ({
     outwardDayLabel: stopDayLabel(
-      tripDate,
       dayOffsets.outward[i] ?? 0,
       hasDayChange,
       fallback
     ),
     inwardDayLabel: stop?.inwardTime
-      ? stopDayLabel(
-          tripDate,
-          dayOffsets.inward[i] ?? 0,
-          hasDayChange,
-          fallback
-        )
+      ? stopDayLabel(dayOffsets.inward[i] ?? 0, hasDayChange, fallback)
       : null,
     outwardDayOffset: dayOffsets.outward[i] ?? 0,
     inwardDayOffset: dayOffsets.inward[i] ?? 0,

--- a/src/features/commute/time-utils.ts
+++ b/src/features/commute/time-utils.ts
@@ -1,0 +1,199 @@
+import dayjs from 'dayjs';
+import '@/lib/dayjs/config';
+
+/**
+ * Time helpers shared across the commute / commute-template features.
+ *
+ * Times are stored as "HH:mm" strings. Because a stop has no date of its
+ * own, a return ("inward") time that is earlier than the outward time is
+ * interpreted as happening the next day rather than being rejected.
+ */
+
+export const timeToMinutes = (time: string): number => {
+  const [hours = 0, minutes = 0] = time.split(':').map(Number);
+  return hours * 60 + minutes;
+};
+
+export const minutesToTime = (minutes: number): string => {
+  // Normalise onto [0, 1440) so negative or >24h values (e.g. an auto-computed
+  // inward time when the outward leg crosses midnight) wrap to a valid wall
+  // clock. The error is always a whole number of days, which the modulo erases.
+  const total = ((minutes % 1440) + 1440) % 1440;
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+};
+
+/**
+ * True when `time` falls on the day after `referenceTime`, i.e. it crosses
+ * midnight relative to the trip's anchor (the departure time).
+ *
+ * A commute is anchored at its first outward time; any later time whose
+ * clock value is smaller has wrapped past midnight (e.g. departure 23:30,
+ * arrival 00:15, or departure 15:00, return 02:00).
+ *
+ * Strict comparison: a time equal to the reference is not a next-day case
+ * (an identical time is rejected as invalid by the validation rules).
+ */
+export const isNextDay = (
+  referenceTime?: string | null,
+  time?: string | null
+): boolean =>
+  !!referenceTime &&
+  !!time &&
+  timeToMinutes(time) < timeToMinutes(referenceTime);
+
+type DayOffsetStop = {
+  outwardTime?: string | null;
+  inwardTime?: string | null;
+};
+
+type DayOffsets = { outward: number[]; inward: number[] };
+
+/**
+ * Cumulative day offset (0 = same day as the commute date, 1 = next day, …)
+ * for every stop, following the real chronology of the trip.
+ *
+ * The offset only ever increases along the timeline, so once the journey has
+ * crossed midnight everything after it stays on the next day — even if its
+ * clock value looks "earlier". For example, if the outward leg arrives after
+ * midnight, the return departure from that same stop is necessarily the next
+ * day too, whatever its clock value.
+ *
+ * - Outward: stops in array order; each backward clock jump adds a day.
+ * - Inward: chronological order is the reverse (the return departs from the
+ *   last stop, where the outward arrived, then works back to the first stop).
+ */
+export const computeDayOffsets = (
+  stops: ReadonlyArray<DayOffsetStop | undefined>
+): { outward: number[]; inward: number[] } => {
+  const n = stops.length;
+  const outward: number[] = Array.from({ length: n }, () => 0);
+  const inward: number[] = Array.from({ length: n }, () => 0);
+
+  for (let i = 1; i < n; i++) {
+    const crossed = isNextDay(stops[i - 1]?.outwardTime, stops[i]?.outwardTime);
+    outward[i] = (outward[i - 1] ?? 0) + (crossed ? 1 : 0);
+  }
+
+  for (let i = n - 1; i >= 0; i--) {
+    if (i === n - 1) {
+      // Return departs from the last stop, after the outward arrived there.
+      const crossed = isNextDay(stops[i]?.outwardTime, stops[i]?.inwardTime);
+      inward[i] = (outward[i] ?? 0) + (crossed ? 1 : 0);
+    } else {
+      // The chronologically previous return event is the next stop by index.
+      const crossed = isNextDay(stops[i + 1]?.inwardTime, stops[i]?.inwardTime);
+      inward[i] = (inward[i + 1] ?? 0) + (crossed ? 1 : 0);
+    }
+  }
+
+  return { outward, inward };
+};
+
+/**
+ * Elapsed minutes of the outward leg (first → last stop), accounting for any
+ * midnight crossing via the cumulative day offset. So an outward leg from
+ * 23:30 to 00:15 is 45 min, not a negative raw-clock difference. Always >= 0.
+ */
+export const outwardDurationMinutes = (
+  stops: ReadonlyArray<DayOffsetStop | undefined>,
+  // Optional precomputed offsets, so callers that already have them (e.g.
+  // alongside `computeStopDayLabels`) don't pay for a second computation.
+  precomputedOffsets?: DayOffsets
+): number => {
+  const first = stops[0];
+  const last = stops[stops.length - 1];
+  if (stops.length < 2 || !first?.outwardTime || !last?.outwardTime) return 0;
+  const { outward } = precomputedOffsets ?? computeDayOffsets(stops);
+  return (
+    timeToMinutes(last.outwardTime) +
+    (outward[stops.length - 1] ?? 0) * 1440 -
+    timeToMinutes(first.outwardTime)
+  );
+};
+
+/**
+ * A trip date shifted by `dayOffset` days, formatted with the shared
+ * `common:short` date format (rather than a hardcoded pattern) so the day
+ * badges follow the project-wide date convention.
+ */
+export const formatTripDate = (tripDate: Date, dayOffset: number): string =>
+  dayjs(tripDate).add(dayOffset, 'day').f('common:short');
+
+/**
+ * True when at least one leg of the trip crosses midnight, i.e. a stop lands
+ * on a later day than the commute date. A missing inward time never counts.
+ */
+export const tripCrossesMidnight = (
+  stops: ReadonlyArray<DayOffsetStop | undefined>,
+  dayOffsets: DayOffsets
+): boolean =>
+  stops.some(
+    (s, i) =>
+      (dayOffsets.outward[i] ?? 0) >= 1 ||
+      (!!s?.inwardTime && (dayOffsets.inward[i] ?? 0) >= 1)
+  );
+
+/**
+ * Per-stop day badge label, shared by the form steps and the recap so they
+ * stay consistent.
+ *
+ * As soon as the trip crosses midnight at least once (`hasDayChange`), **every**
+ * stop carries a label so the reader can tell the days apart — its exact date
+ * when the trip date is known, or the generic `fallback` (next-day) for dateless
+ * templates (and only on the crossed stops in that case). No crossing → no
+ * per-stop badge at all.
+ */
+export const stopDayLabel = (
+  tripDate: Date | null | undefined,
+  dayOffset: number,
+  hasDayChange: boolean,
+  fallback: string
+): string | null => {
+  if (!hasDayChange) return null;
+  if (tripDate) return formatTripDate(tripDate, dayOffset);
+  return dayOffset >= 1 ? fallback : null;
+};
+
+export type StopDayLabels = {
+  outwardDayLabel: string | null;
+  inwardDayLabel: string | null;
+};
+
+/**
+ * Per-stop day badge labels (outward + inward) for a whole trip, ready to be
+ * merged into the timeline stops. Centralises the day-offset computation so the
+ * form recap and the read-only consultation views stay consistent.
+ *
+ * The inward label is only produced when the stop actually carries a return
+ * time. Each stop keeps its original index, so the offsets line up with the
+ * array order (no reversing needed by the caller).
+ */
+export const computeStopDayLabels = (
+  stops: ReadonlyArray<DayOffsetStop | undefined>,
+  tripDate: Date | null | undefined,
+  fallback: string,
+  // Optional precomputed offsets, shared with callers that also need the raw
+  // offsets (e.g. to compute the trip duration) to avoid recomputing them.
+  precomputedOffsets?: DayOffsets
+): StopDayLabels[] => {
+  const dayOffsets = precomputedOffsets ?? computeDayOffsets(stops);
+  const hasDayChange = tripCrossesMidnight(stops, dayOffsets);
+  return stops.map((stop, i) => ({
+    outwardDayLabel: stopDayLabel(
+      tripDate,
+      dayOffsets.outward[i] ?? 0,
+      hasDayChange,
+      fallback
+    ),
+    inwardDayLabel: stop?.inwardTime
+      ? stopDayLabel(
+          tripDate,
+          dayOffsets.inward[i] ?? 0,
+          hasDayChange,
+          fallback
+        )
+      : null,
+  }));
+};

--- a/src/features/commute/time-utils.unit.test.ts
+++ b/src/features/commute/time-utils.unit.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeStopDayLabels,
+  minutesToTime,
+  outwardDurationMinutes,
+  timeToMinutes,
+} from '@/features/commute/time-utils';
+
+const TRIP_DATE = new Date('2026-06-29T00:00:00');
+
+describe('minutesToTime', () => {
+  it('formats a regular time', () => {
+    expect(minutesToTime(timeToMinutes('08:05'))).toBe('08:05');
+    expect(minutesToTime(timeToMinutes('23:59'))).toBe('23:59');
+    expect(minutesToTime(0)).toBe('00:00');
+  });
+
+  it('wraps values past midnight', () => {
+    // 24:30 -> 00:30 the next day
+    expect(minutesToTime(24 * 60 + 30)).toBe('00:30');
+  });
+
+  it('never produces an invalid time, even for negative minutes', () => {
+    // Reachable via the auto-computed inward times when the OUTWARD leg
+    // crosses midnight: lastInward + (lastOutward - stopOutward) can go
+    // negative, e.g. last outward 00:15, stop0 outward 23:30, last inward 01:00
+    //   => 60 + (15 - 1410) = -1335
+    const result = minutesToTime(60 + (15 - 1410));
+    expect(result).toMatch(/^([01]\d|2[0-3]):[0-5]\d$/);
+  });
+});
+
+describe('outwardDurationMinutes', () => {
+  it('computes a same-day outward duration', () => {
+    expect(
+      outwardDurationMinutes([
+        { outwardTime: '08:00' },
+        { outwardTime: '09:30' },
+      ])
+    ).toBe(90);
+  });
+
+  it('returns a real elapsed time when the outward leg crosses midnight', () => {
+    // 23:30 -> 00:15 is 45 min, not -1395 (the raw clock difference).
+    expect(
+      outwardDurationMinutes([
+        { outwardTime: '23:30' },
+        { outwardTime: '00:15' },
+      ])
+    ).toBe(45);
+  });
+
+  it('accumulates across several stops crossing midnight', () => {
+    // 22:00 -> 23:00 -> 01:00 spans 3h.
+    expect(
+      outwardDurationMinutes([
+        { outwardTime: '22:00' },
+        { outwardTime: '23:00' },
+        { outwardTime: '01:00' },
+      ])
+    ).toBe(180);
+  });
+
+  it('is safe with fewer than two stops or missing times', () => {
+    expect(outwardDurationMinutes([{ outwardTime: '08:00' }])).toBe(0);
+    expect(outwardDurationMinutes([])).toBe(0);
+  });
+});
+
+describe('computeStopDayLabels', () => {
+  it('produces no labels when the trip stays on one day', () => {
+    const labels = computeStopDayLabels(
+      [
+        { outwardTime: '08:00', inwardTime: '17:30' },
+        { outwardTime: '08:30', inwardTime: '17:00' },
+      ],
+      TRIP_DATE,
+      'Lendemain'
+    );
+    expect(labels).toEqual([
+      { outwardDayLabel: null, inwardDayLabel: null },
+      { outwardDayLabel: null, inwardDayLabel: null },
+    ]);
+  });
+
+  it('labels every stop with its exact date when the return crosses midnight', () => {
+    // Outward stays on day 0, the return (02:00) is read as the next day.
+    const labels = computeStopDayLabels(
+      [
+        { outwardTime: '15:00', inwardTime: '02:20' },
+        { outwardTime: '15:30', inwardTime: '02:00' },
+      ],
+      TRIP_DATE,
+      'Lendemain'
+    );
+    expect(labels).toEqual([
+      { outwardDayLabel: '29/06/2026', inwardDayLabel: '30/06/2026' },
+      { outwardDayLabel: '29/06/2026', inwardDayLabel: '30/06/2026' },
+    ]);
+  });
+
+  it('falls back to the generic label on crossed stops when there is no date (templates)', () => {
+    const labels = computeStopDayLabels(
+      [
+        { outwardTime: '15:00', inwardTime: '02:20' },
+        { outwardTime: '15:30', inwardTime: '02:00' },
+      ],
+      null,
+      'Lendemain'
+    );
+    // Day-0 outward stops get no badge, only the next-day returns do.
+    expect(labels).toEqual([
+      { outwardDayLabel: null, inwardDayLabel: 'Lendemain' },
+      { outwardDayLabel: null, inwardDayLabel: 'Lendemain' },
+    ]);
+  });
+
+  it('never sets an inward label when the stop has no return time', () => {
+    const labels = computeStopDayLabels(
+      [
+        { outwardTime: '23:30', inwardTime: null },
+        { outwardTime: '00:15', inwardTime: null },
+      ],
+      TRIP_DATE,
+      'Lendemain'
+    );
+    expect(labels[0]?.inwardDayLabel).toBeNull();
+    expect(labels[1]?.inwardDayLabel).toBeNull();
+    // The outward leg crosses midnight, so the post-midnight stop is day 1.
+    expect(labels[1]?.outwardDayLabel).toBe('30/06/2026');
+  });
+});

--- a/src/features/commute/time-utils.unit.test.ts
+++ b/src/features/commute/time-utils.unit.test.ts
@@ -7,7 +7,10 @@ import {
   timeToMinutes,
 } from '@/features/commute/time-utils';
 
-const TRIP_DATE = new Date('2026-06-29T00:00:00');
+// Mirrors the offset-aware i18n fallback: "Jour J" at 0, "Lendemain" at +1,
+// "+N jours" beyond.
+const dayBadge = (offset: number) =>
+  offset === 0 ? 'Jour J' : offset === 1 ? 'Lendemain' : `+${offset} jours`;
 
 describe('minutesToTime', () => {
   it('formats a regular time', () => {
@@ -75,8 +78,7 @@ describe('computeStopDayLabels', () => {
         { outwardTime: '08:00', inwardTime: '17:30' },
         { outwardTime: '08:30', inwardTime: '17:00' },
       ],
-      TRIP_DATE,
-      'Lendemain'
+      dayBadge
     );
     expect(labels).toEqual([
       {
@@ -94,56 +96,49 @@ describe('computeStopDayLabels', () => {
     ]);
   });
 
-  it('labels every stop with its exact date when the return crosses midnight', () => {
-    // Outward stays on day 0, the return (02:00) is read as the next day.
+  it('labels every stop once the return crosses midnight ("Jour J" then "Lendemain")', () => {
+    // The outward stays on day 0 ("Jour J"), the return (02:00) is read as the
+    // next day ("Lendemain"), so the days can be told apart at a glance.
     const labels = computeStopDayLabels(
       [
         { outwardTime: '15:00', inwardTime: '02:20' },
         { outwardTime: '15:30', inwardTime: '02:00' },
       ],
-      TRIP_DATE,
-      'Lendemain'
+      dayBadge
     );
     expect(labels).toEqual([
       {
-        outwardDayLabel: '29/06/2026',
-        inwardDayLabel: '30/06/2026',
+        outwardDayLabel: 'Jour J',
+        inwardDayLabel: 'Lendemain',
         outwardDayOffset: 0,
         inwardDayOffset: 1,
       },
       {
-        outwardDayLabel: '29/06/2026',
-        inwardDayLabel: '30/06/2026',
+        outwardDayLabel: 'Jour J',
+        inwardDayLabel: 'Lendemain',
         outwardDayOffset: 0,
         inwardDayOffset: 1,
       },
     ]);
   });
 
-  it('falls back to the generic label on crossed stops when there is no date (templates)', () => {
+  it('uses the day offset in the relative label when a trip spans several days', () => {
+    // Regression: each backward clock jump on the outward leg adds a day, so a
+    // trip spanning 3 days must read "Jour J" / "Lendemain" / "+2 jours".
     const labels = computeStopDayLabels(
       [
-        { outwardTime: '15:00', inwardTime: '02:20' },
-        { outwardTime: '15:30', inwardTime: '02:00' },
+        { outwardTime: '15:00' },
+        { outwardTime: '10:00' },
+        { outwardTime: '09:00' },
       ],
-      null,
-      'Lendemain'
+      dayBadge
     );
-    // Day-0 outward stops get no badge, only the next-day returns do.
-    expect(labels).toEqual([
-      {
-        outwardDayLabel: null,
-        inwardDayLabel: 'Lendemain',
-        outwardDayOffset: 0,
-        inwardDayOffset: 1,
-      },
-      {
-        outwardDayLabel: null,
-        inwardDayLabel: 'Lendemain',
-        outwardDayOffset: 0,
-        inwardDayOffset: 1,
-      },
+    expect(labels.map((l) => l.outwardDayLabel)).toEqual([
+      'Jour J',
+      'Lendemain',
+      '+2 jours',
     ]);
+    expect(labels.map((l) => l.outwardDayOffset)).toEqual([0, 1, 2]);
   });
 
   it('never sets an inward label when the stop has no return time', () => {
@@ -152,12 +147,13 @@ describe('computeStopDayLabels', () => {
         { outwardTime: '23:30', inwardTime: null },
         { outwardTime: '00:15', inwardTime: null },
       ],
-      TRIP_DATE,
-      'Lendemain'
+      dayBadge
     );
     expect(labels[0]?.inwardDayLabel).toBeNull();
     expect(labels[1]?.inwardDayLabel).toBeNull();
-    // The outward leg crosses midnight, so the post-midnight stop is day 1.
-    expect(labels[1]?.outwardDayLabel).toBe('30/06/2026');
+    // The outward leg crosses midnight: day 0 is "Jour J", the post-midnight
+    // stop is "Lendemain".
+    expect(labels[0]?.outwardDayLabel).toBe('Jour J');
+    expect(labels[1]?.outwardDayLabel).toBe('Lendemain');
   });
 });

--- a/src/features/commute/time-utils.unit.test.ts
+++ b/src/features/commute/time-utils.unit.test.ts
@@ -79,8 +79,18 @@ describe('computeStopDayLabels', () => {
       'Lendemain'
     );
     expect(labels).toEqual([
-      { outwardDayLabel: null, inwardDayLabel: null },
-      { outwardDayLabel: null, inwardDayLabel: null },
+      {
+        outwardDayLabel: null,
+        inwardDayLabel: null,
+        outwardDayOffset: 0,
+        inwardDayOffset: 0,
+      },
+      {
+        outwardDayLabel: null,
+        inwardDayLabel: null,
+        outwardDayOffset: 0,
+        inwardDayOffset: 0,
+      },
     ]);
   });
 
@@ -95,8 +105,18 @@ describe('computeStopDayLabels', () => {
       'Lendemain'
     );
     expect(labels).toEqual([
-      { outwardDayLabel: '29/06/2026', inwardDayLabel: '30/06/2026' },
-      { outwardDayLabel: '29/06/2026', inwardDayLabel: '30/06/2026' },
+      {
+        outwardDayLabel: '29/06/2026',
+        inwardDayLabel: '30/06/2026',
+        outwardDayOffset: 0,
+        inwardDayOffset: 1,
+      },
+      {
+        outwardDayLabel: '29/06/2026',
+        inwardDayLabel: '30/06/2026',
+        outwardDayOffset: 0,
+        inwardDayOffset: 1,
+      },
     ]);
   });
 
@@ -111,8 +131,18 @@ describe('computeStopDayLabels', () => {
     );
     // Day-0 outward stops get no badge, only the next-day returns do.
     expect(labels).toEqual([
-      { outwardDayLabel: null, inwardDayLabel: 'Lendemain' },
-      { outwardDayLabel: null, inwardDayLabel: 'Lendemain' },
+      {
+        outwardDayLabel: null,
+        inwardDayLabel: 'Lendemain',
+        outwardDayOffset: 0,
+        inwardDayOffset: 1,
+      },
+      {
+        outwardDayLabel: null,
+        inwardDayLabel: 'Lendemain',
+        outwardDayOffset: 0,
+        inwardDayOffset: 1,
+      },
     ]);
   });
 

--- a/src/features/commute/use-auto-inward-times.ts
+++ b/src/features/commute/use-auto-inward-times.ts
@@ -2,17 +2,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { Control, UseFormReturn, useWatch } from 'react-hook-form';
 
 import type { FormFieldsCommuteBase } from '@/features/commute/schema';
-
-const timeToMinutes = (time: string): number => {
-  const [hours = 0, minutes = 0] = time.split(':').map(Number);
-  return hours * 60 + minutes;
-};
-
-const minutesToTime = (minutes: number): string => {
-  const h = Math.floor(minutes / 60) % 24;
-  const m = minutes % 60;
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-};
+import { minutesToTime, timeToMinutes } from '@/features/commute/time-utils';
 
 /**
  * Auto-computes inward times for stops before the last one,

--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -76,6 +76,7 @@ export const PageDashboard = () => {
           commuteType: commute.type as CommuteType,
           commuteDate: commute.date,
           stop: stop as StopEnriched,
+          commuteStops: commute.stops as StopEnriched[],
           driver: commute.driver as UserSummary,
           driverMemberId: commute.driverMemberId,
           isFirstStop: stop.order === minOrder,
@@ -246,6 +247,7 @@ export const PageDashboard = () => {
           commuteType={bookingInfo?.commuteType ?? 'ROUND'}
           commuteDate={bookingInfo?.commuteDate ?? FALLBACK_DATE}
           stop={bookingInfo?.stop ?? null}
+          commuteStops={bookingInfo?.commuteStops ?? []}
           driver={bookingInfo?.driver ?? null}
           isFirstStop={bookingInfo?.isFirstStop ?? false}
           isLastStop={bookingInfo?.isLastStop ?? false}

--- a/src/features/dashboard/dashboard-commute-card.tsx
+++ b/src/features/dashboard/dashboard-commute-card.tsx
@@ -121,6 +121,7 @@ export const DashboardCommuteCard = ({
                                   `commute:list.type.${commute.type}`
                                 )}
                                 stops={[stop]}
+                                tripStops={commute.stops}
                               />
                             </div>
                           }

--- a/src/features/dashboard/dashboard-commute-card.tsx
+++ b/src/features/dashboard/dashboard-commute-card.tsx
@@ -81,6 +81,7 @@ export const DashboardCommuteCard = ({
           inwardTaken={commute.type === 'ROUND' ? inwardCount : undefined}
           outwardDeparture={commute.stops.at(0)?.outwardTime}
           inwardDeparture={commute.stops.at(-1)?.inwardTime ?? undefined}
+          date={commute.date}
           stops={commute.stops}
           passengers={[...acceptedPassengers.values()]}
           badge={bookingStatus && <BookingStatusBadge status={bookingStatus} />}

--- a/src/features/dashboard/dashboard-commute-card.tsx
+++ b/src/features/dashboard/dashboard-commute-card.tsx
@@ -81,7 +81,6 @@ export const DashboardCommuteCard = ({
           inwardTaken={commute.type === 'ROUND' ? inwardCount : undefined}
           outwardDeparture={commute.stops.at(0)?.outwardTime}
           inwardDeparture={commute.stops.at(-1)?.inwardTime ?? undefined}
-          date={commute.date}
           stops={commute.stops}
           passengers={[...acceptedPassengers.values()]}
           badge={bookingStatus && <BookingStatusBadge status={bookingStatus} />}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,6 +1,8 @@
 {
   "or": "or",
-  "nextDay": "Next day",
+  "dayBadge_zero": "D-day",
+  "dayBadge_one": "Next day",
+  "dayBadge_other": "+{{count}} days",
   "languages": {
     "label": "Language",
     "values": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "or": "or",
+  "nextDay": "Next day",
   "languages": {
     "label": "Language",
     "values": {

--- a/src/locales/en/commute-template.json
+++ b/src/locales/en/commute-template.json
@@ -47,9 +47,9 @@
     "errors": {
       "seatsMin": "At least 1 seat is required",
       "stopsMin": "At least 2 stops are required",
-      "inwardBeforeOutward": "Inbound time must be after outbound time",
-      "outwardNotIncreasing": "Must be after the previous stop's outbound time",
-      "inwardNotDecreasing": "Must be before the previous stop's inbound time"
+      "inwardSameAsOutward": "Inbound time must differ from outbound time",
+      "outwardSameAsPrev": "Must differ from the previous stop's outbound time",
+      "inwardSameAsPrev": "Must differ from the previous stop's inbound time"
     }
   }
 }

--- a/src/locales/en/commute.json
+++ b/src/locales/en/commute.json
@@ -100,11 +100,11 @@
     "errors": {
       "seatsMin": "At least 1 seat required",
       "stopsMin": "At least 2 stops required",
-      "inwardBeforeOutward": "Inbound time must be after outbound time",
+      "inwardSameAsOutward": "Inbound time must differ from outbound time",
       "inwardInPast": "Inbound time must be in the future",
       "outwardInPast": "Outbound time must be in the future",
-      "outwardNotIncreasing": "Must be after the previous stop's outbound time",
-      "inwardNotDecreasing": "Must be before the previous stop's inbound time",
+      "outwardSameAsPrev": "Must differ from the previous stop's outbound time",
+      "inwardSameAsPrev": "Must differ from the previous stop's inbound time",
       "datePast": "Date must be today or in the future"
     }
   }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -1,5 +1,6 @@
 {
   "or": "ou",
+  "nextDay": "Lendemain",
   "languages": {
     "label": "Langue",
     "values": {

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -1,6 +1,8 @@
 {
   "or": "ou",
-  "nextDay": "Lendemain",
+  "dayBadge_zero": "Jour J",
+  "dayBadge_one": "Lendemain",
+  "dayBadge_other": "+{{count}} jours",
   "languages": {
     "label": "Langue",
     "values": {

--- a/src/locales/fr/commute-template.json
+++ b/src/locales/fr/commute-template.json
@@ -47,9 +47,9 @@
     "errors": {
       "seatsMin": "Au moins 1 place est requise",
       "stopsMin": "Au moins 2 arrêts sont requis",
-      "inwardBeforeOutward": "L'heure retour doit être après l'heure aller",
-      "outwardNotIncreasing": "Doit être après l'heure aller de l'arrêt précédent",
-      "inwardNotDecreasing": "Doit être avant l'heure retour de l'arrêt précédent"
+      "inwardSameAsOutward": "L'heure retour doit être différente de l'heure aller",
+      "outwardSameAsPrev": "Doit être différente de l'heure aller de l'arrêt précédent",
+      "inwardSameAsPrev": "Doit être différente de l'heure retour de l'arrêt précédent"
     }
   }
 }

--- a/src/locales/fr/commute.json
+++ b/src/locales/fr/commute.json
@@ -100,11 +100,11 @@
     "errors": {
       "seatsMin": "Au moins 1 place requise",
       "stopsMin": "Au moins 2 arrêts requis",
-      "inwardBeforeOutward": "L'heure retour doit être après l'heure aller",
+      "inwardSameAsOutward": "L'heure retour doit être différente de l'heure aller",
       "inwardInPast": "L'heure retour doit être dans le futur",
       "outwardInPast": "L'heure aller doit être dans le futur",
-      "outwardNotIncreasing": "Doit être après l'heure aller de l'arrêt précédent",
-      "inwardNotDecreasing": "Doit être avant l'heure retour de l'arrêt précédent",
+      "outwardSameAsPrev": "Doit être différente de l'heure aller de l'arrêt précédent",
+      "inwardSameAsPrev": "Doit être différente de l'heure retour de l'arrêt précédent",
       "datePast": "La date doit être aujourd'hui ou dans le futur"
     }
   }


### PR DESCRIPTION
## Summary

Commute times are stored as plain `HH:mm` strings with no date of their own,
so the previous validation rejected any return/next-stop time that was
"earlier" than the one before it. That made it impossible to create a commute
that crosses midnight (e.g. departure 23:30 => arrival 00:15, or departure
15:00 => return 02:00).

This branch reinterprets an earlier time as *the next day* instead of rejecting
it, and propagates that day-offset through validation, time computation and the
UI.

## Changes

### Time handling
- Add `src/features/commute/time-utils.ts` with shared helpers:
  - `timeToMinutes` / `minutesToTime` (the latter normalises onto `[0, 1440)`
    so wrapped/negative values map back to a valid wall clock).
  - `isNextDay` — true when a time crosses midnight relative to the trip anchor.
  - `computeDayOffsets` — cumulative day offset per stop following the real
    chronology of the trip (outward in array order, inward in reverse), so once
    the journey crosses midnight everything after it stays on the next day.

### Validation rules
- Relax stop-ordering rules: distinct adjacent times are now always valid (a
  smaller value simply means the trip crossed midnight); only an *identical*
  time is rejected.
  - `shouldInwardBeAfterOutward` → `shouldInwardDifferFromOutward`
  - `shouldOutwardBeIncreasing` → `shouldOutwardDifferFromPrev`
  - `shouldInwardBeDecreasing` → `shouldInwardDifferFromPrev`
- `isOutwardInFuture` / `isInwardInFuture` now take the stop `index` and apply
  its day offset so "in the future" checks are correct across midnight.
- Update error messages accordingly (FR + EN locales).

### UI
- Replace the date badge with a relative **D-day / Next day / +N days** badge
  (`dayBadge` pluralised key in `common.json`) on the stops timeline, recap and
  confirm-summary views.
- Fix incorrect date rendering when a leg crosses midnight.
- Add a dedicated mobile layout for the stops timeline to handle size
  differences.

### Seed & tests
- Update the commute seed generator to use the new time system.
- Add unit tests for `time-utils.ts` and for the updated commute rules; fix
  existing rule tests.

## Test plan
- [x] `time-utils` unit tests
- [x] commute rules unit tests
- [x] Manually create a commute crossing midnight (23:30 => 00:15) and confirm validation passes and the badge/date display correctly on desktop and mobile.

## Closed subject

### Issue
close #154 

### Old pr
 #238 