### PR TITLE
fix(search): serialize dates to YYYY-MM-DD in search params

### DIFF
--- a/src/features/commute-request/commute-request-card.tsx
+++ b/src/features/commute-request/commute-request-card.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import '@/lib/dayjs/config';
 
+import { toDateParam } from '@/lib/dayjs/date-param';
 import { orpc } from '@/lib/orpc/client';
 
 import { CommentText } from '@/components/comment-text';
@@ -106,7 +107,10 @@ export const CommuteRequestCard = ({
             className="flex-1"
             size="sm"
             to="/app/$orgSlug/commutes/new"
-            search={{ date: request.date, commuteRequestIds: [request.id] }}
+            search={{
+              date: toDateParam(request.date),
+              commuteRequestIds: [request.id],
+            }}
             viewTransition={{ types: ['slide-up'] }}
           >
             {t('commuteRequest:actions.offerRide')}

--- a/src/features/dashboard/app/page-dashboard.tsx
+++ b/src/features/dashboard/app/page-dashboard.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import '@/lib/dayjs/config';
 
+import { toDateParam } from '@/lib/dayjs/date-param';
 import { featureIcons } from '@/lib/feature-icons';
 import { orpc } from '@/lib/orpc/client';
 import { cn } from '@/lib/tailwind/utils';
@@ -189,7 +190,7 @@ export const PageDashboard = () => {
                     {dayCommutes.length === 0 ? (
                       <OrgLink
                         to="/app/$orgSlug/commutes/new"
-                        search={{ date: day.toDate() }}
+                        search={{ date: toDateParam(day.toDate()) }}
                         className="block"
                         viewTransition={{ types: ['slide-up'] }}
                       >

--- a/src/features/slack/templates/commute-requested.tsx
+++ b/src/features/slack/templates/commute-requested.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource jsx-slack */
 import { Blocks, Button } from 'jsx-slack';
 
+import { toDateParam } from '@/lib/dayjs/date-param';
 import i18n from '@/lib/i18n';
 import { routeUrl } from '@/lib/route-url';
 
@@ -18,10 +19,11 @@ type Props = {
 };
 
 export function CommuteRequested({ event, baseUrl, requesterSlackId }: Props) {
-  const dateParam =
+  const dateParam = toDateParam(
     event.payload.commuteDate instanceof Date
-      ? event.payload.commuteDate.toISOString()
-      : String(event.payload.commuteDate);
+      ? event.payload.commuteDate
+      : new Date(String(event.payload.commuteDate))
+  );
 
   const link = routeUrl(baseUrl, '/app/$orgSlug/commutes/new', {
     params: { orgSlug: event.payload.orgSlug },

--- a/src/lib/dayjs/date-param.ts
+++ b/src/lib/dayjs/date-param.ts
@@ -1,0 +1,22 @@
+import dayjs from 'dayjs';
+
+import { toNoonUTC } from './to-noon-utc';
+
+/**
+ * Serialize a date-only value for use in a URL search param (`YYYY-MM-DD`).
+ *
+ * Search param values must round-trip unchanged through `validateSearch`,
+ * otherwise the router keeps redirecting to "normalize" them. Keeping the param
+ * a plain string (instead of transforming it into a `Date`) guarantees that.
+ */
+export function toDateParam(date: Date): string {
+  return toNoonUTC(date).toISOString().slice(0, 10);
+}
+
+/**
+ * Parse a date search param back into a `Date` at noon UTC on the same
+ * calendar day. Accepts `YYYY-MM-DD` as well as full ISO strings.
+ */
+export function fromDateParam(value: string): Date {
+  return toNoonUTC(dayjs(value).toDate());
+}

--- a/src/lib/dayjs/date-param.unit.spec.ts
+++ b/src/lib/dayjs/date-param.unit.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { fromDateParam, toDateParam } from '@/lib/dayjs/date-param';
+
+describe('date-param', () => {
+  it('serializes a date to a calendar day', () => {
+    expect(toDateParam(new Date(2026, 6, 30, 23, 30))).toBe('2026-07-30');
+    expect(toDateParam(new Date(2026, 6, 30, 0, 30))).toBe('2026-07-30');
+  });
+
+  it('parses a calendar day to noon UTC', () => {
+    expect(fromDateParam('2026-07-30').toISOString()).toBe(
+      '2026-07-30T12:00:00.000Z'
+    );
+  });
+
+  it('parses legacy full ISO params', () => {
+    expect(fromDateParam('2026-07-30T12:00:00.000Z').toISOString()).toBe(
+      '2026-07-30T12:00:00.000Z'
+    );
+  });
+
+  it('round-trips without drifting', () => {
+    const param = '2026-07-30';
+    expect(toDateParam(fromDateParam(param))).toBe(param);
+  });
+});

--- a/src/routes/app/$orgSlug/commutes/new.index.tsx
+++ b/src/routes/app/$orgSlug/commutes/new.index.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { fallback, zodValidator } from '@tanstack/zod-adapter';
+import dayjs from 'dayjs';
+import { useMemo } from 'react';
 import { z } from 'zod';
 
-import { toNoonUTC } from '@/lib/dayjs/to-noon-utc';
+import { fromDateParam, toDateParam } from '@/lib/dayjs/date-param';
 
 import { PageCommuteNew } from '@/features/commute/app/page-commute-new';
 
@@ -10,8 +12,13 @@ export const Route = createFileRoute('/app/$orgSlug/commutes/new/')({
   component: RouteComponent,
   validateSearch: zodValidator(
     z.object({
+      // Kept as a raw string on purpose: validated search params must round-trip
+      // unchanged, otherwise the router endlessly redirects to normalize them.
       date: fallback(
-        z.coerce.date().transform((d) => toNoonUTC(d)),
+        z
+          .string()
+          .refine((value) => dayjs(value).isValid())
+          .optional(),
         undefined
       ).optional(),
       commuteRequestIds: z
@@ -26,8 +33,16 @@ export const Route = createFileRoute('/app/$orgSlug/commutes/new/')({
 
 function RouteComponent() {
   const { orgSlug } = Route.useParams();
-  const search = Route.useSearch();
+  const { date, commuteRequestIds } = Route.useSearch();
   const navigate = Route.useNavigate();
+
+  const search = useMemo(
+    () => ({
+      date: date ? fromDateParam(date) : undefined,
+      commuteRequestIds,
+    }),
+    [date, commuteRequestIds]
+  );
 
   return (
     <PageCommuteNew
@@ -36,7 +51,10 @@ function RouteComponent() {
       onDateChange={(date) =>
         navigate({
           replace: true,
-          search: (prev) => ({ ...prev, date }),
+          search: (prev) => ({
+            ...prev,
+            date: date ? toDateParam(date) : undefined,
+          }),
         })
       }
     />


### PR DESCRIPTION
## Summary

- Create `date-param` utility functions (`toDateParam()`, `fromDateParam()`) to consistently serialize/deserialize dates as `YYYY-MM-DD` strings in URL search parameters
- Change route validation to keep date params as strings instead of coercing to `Date` objects, preventing router redirects during param normalization
- Update commute request card, dashboard, and Slack notification templates to use `toDateParam()` when setting search params
- Add comprehensive unit tests for round-trip serialization

## Testing

- Unit tests pass: `date-param.unit.spec.ts` verifies serialization format, parsing, and round-trip stability
- Manual: Navigate from dashboard to create commute with date param — URL should contain `date=YYYY-MM-DD` format
- Manual: Click "Offer ride" from a commute request card — URL should maintain date param without router redirect loops
- Manual: Verify Slack notification links construct the date param correctly for both Date objects and string inputs